### PR TITLE
Gate personalized search on /user/isSearchObserver

### DIFF
--- a/client/src/hooks/useIsSearchObserver.ts
+++ b/client/src/hooks/useIsSearchObserver.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient, hasSessionToken } from "@/services/api";
+
+/**
+ * Whether the logged-in user is allowed to run search from their own trust
+ * perspective ("search observer"), backed by `GET /user/isSearchObserver`.
+ *
+ * Defaults to `false` (house / NosFabrica perspective) when logged out, while
+ * loading, or on error — so personalized search is only ever enabled once the
+ * backend explicitly confirms it. Gated on `hasSessionToken()` so it never
+ * fires for anonymous visitors (that path goes through `authenticatedFetch`,
+ * which can 401-redirect public pages).
+ */
+export function useIsSearchObserver(): { isSearchObserver: boolean; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["/user/isSearchObserver"],
+    queryFn: () => apiClient.getIsSearchObserver(),
+    enabled: hasSessionToken(),
+    staleTime: 60_000,
+  });
+
+  return {
+    isSearchObserver: query.data ?? false,
+    isLoading: hasSessionToken() && query.isPending,
+  };
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -26,6 +26,7 @@ import { queryClient } from "@/lib/queryClient";
 import { apiClient } from "@/services/api";
 import { useActivePov } from "@/hooks/useActivePov";
 import { useHasMywot } from "@/hooks/useHasMywot";
+import { useIsSearchObserver } from "@/hooks/useIsSearchObserver";
 import { useToast } from "@/hooks/use-toast";
 import { setProfileSeed, setStoredSearchSeed, type ProfileSeed } from "@/lib/profileSeed";
 import {
@@ -123,14 +124,19 @@ export default function Landing() {
   const [user, setUser] = useCurrentUser();
   const [pov, setPov] = useActivePov();
   const { hasMywot } = useHasMywot();
+  // Permission to search from one's own perspective, per GET /user/isSearchObserver.
+  const { isSearchObserver } = useIsSearchObserver();
+  const canUseMywot = hasMywot && isSearchObserver;
 
   // Logged-in users stay on this search-first home and search from their active
-  // trust perspective; "My WoT" gracefully falls back to the house view when no
-  // personalized graph exists yet (and anonymous visitors always use house).
+  // trust perspective; "My WoT" gracefully falls back to the house view unless
+  // the user both has a personalized graph (hasMywot) and is permitted to be
+  // their own search observer (isSearchObserver). Anonymous visitors always use
+  // the house view.
   const effectivePov = useMemo(() => {
     if (!user) return ANON_POV;
-    return pov === "mywot" && !hasMywot ? ANON_POV : pov;
-  }, [user, pov, hasMywot]);
+    return pov === "mywot" && !canUseMywot ? ANON_POV : pov;
+  }, [user, pov, canUseMywot]);
 
   const handleLogout = useCallback(() => {
     logout();
@@ -795,17 +801,23 @@ export default function Landing() {
                 <button
                   type="button"
                   onClick={() => {
-                    if (hasMywot) setPov("mywot");
+                    if (canUseMywot) setPov("mywot");
                   }}
-                  disabled={!hasMywot}
+                  disabled={!canUseMywot}
                   aria-pressed={effectivePov === "mywot"}
-                  title={hasMywot ? undefined : "Calculate your trust network in Settings to enable"}
+                  title={
+                    !hasMywot
+                      ? "Calculate your trust network in Settings to enable"
+                      : !isSearchObserver
+                        ? "Personalized search isn't available for your account yet"
+                        : undefined
+                  }
                   className={
                     "rounded px-1.5 py-0.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/40 " +
                     (effectivePov === "mywot"
                       ? "font-semibold text-emerald-700"
                       : "font-medium text-slate-500 hover:text-slate-700") +
-                    (!hasMywot ? " opacity-50 cursor-not-allowed" : "")
+                    (!canUseMywot ? " opacity-50 cursor-not-allowed" : "")
                   }
                   data-testid="toggle-home-pov-mywot"
                 >


### PR DESCRIPTION
## Summary
On the search page, a logged-in user should only be able to search from **their own** trust perspective when the backend allows it. This wires the existing `GET /user/isSearchObserver` check into the search UI: if it returns `false`, search runs from the house (NosFabrica) perspective — the same as logged out.

## What changed (2 files)
- **`client/src/hooks/useIsSearchObserver.ts`** (new) — `useQuery` hook backed by `apiClient.getIsSearchObserver()` (which already existed in `api.ts`). Gated on `hasSessionToken()`, `staleTime: 60s`. Defaults to `false` while loading / logged out / on error. Mirrors `useHasMywot`.
- **`client/src/pages/landing.tsx`** — feeds `isSearchObserver` into the existing perspective logic:
  - `effectivePov` now falls back to house unless `hasMywot && isSearchObserver` (`canUseMywot`).
  - The "My results" toggle is **shown but disabled** (greyed, with an explanatory tooltip) when the user isn't a permitted search observer — consistent with how the no-graph case already behaves.

`api.ts` is unchanged — `getIsSearchObserver()` was already present; only the UI wiring was missing.

## Behavior
| User state | "My results" toggle | Search perspective |
|---|---|---|
| Logged out | not shown | house (NosFabrica) |
| Logged in, `isSearchObserver: true` (+ graph) | enabled | their own |
| Logged in, `isSearchObserver: false` | disabled (tooltip) | house |
| Logged in, no graph yet | disabled ("Calculate yours") | house |

## Risk / verification
- `tsc` clean, `npm run build` ✓.
- Verified in preview: anonymous home page renders, search works, **no new console errors**.
- ⚠️ The logged-in toggle behavior needs a quick manual check with a real account (couldn't log in headlessly) — reviewer please confirm the toggle disables when `isSearchObserver` is false.

## Test plan
- [x] `tsc`, production build
- [x] Anonymous home/search unaffected (preview)
- [x] Reviewer: logged-in user with `isSearchObserver: false` → "My results" disabled + search uses house perspective
- [x] Reviewer: logged-in user with `isSearchObserver: true` → "My results" enabled + personalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)