### PR TITLE
Verification Score coin + /p hero refinement, /developers redesign

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -41,7 +41,7 @@ import LoginPage from "@/pages/LoginPage";
 import { FEATURES } from "@/config/featureFlags";
 import { PovAutoDefault } from "@/components/PovBadge";
 import { MobileMenuHost } from "@/components/MobileMenuHost";
-import { getCurrentUser } from "@/services/nostr";
+import { getCurrentUser, ensureUnlocked } from "@/services/nostr";
 import type { ComponentType } from "react";
 
 function ScrollToTop() {
@@ -133,6 +133,14 @@ function Router() {
 }
 
 function App() {
+  // Warm up the in-memory secret key on boot so the encrypted-at-rest key is
+  // decrypted (silently, no password) before the first signing action — keeps the
+  // synchronous reveal/backup paths correct. Only for signed-in users (the decrypt
+  // is bound to the account pubkey); anonymous visitors skip the IndexedDB open.
+  useEffect(() => {
+    if (getCurrentUser()) void ensureUnlocked();
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={300} skipDelayDuration={100}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,9 @@ import HowSearchWorksPage from "@/pages/HowSearchWorksPage";
 import PersonalizationPage from "@/pages/PersonalizationPage";
 import AboutPage from "@/pages/AboutPage";
 import DevelopersPage from "@/pages/DevelopersPage";
+import DeveloperNip50Page from "@/pages/DeveloperNip50Page";
+import DeveloperOpenRankingPage from "@/pages/DeveloperOpenRankingPage";
+import DeveloperTrustedAssertionsPage from "@/pages/DeveloperTrustedAssertionsPage";
 import NostrPage from "@/pages/NostrPage";
 import HashtagPage from "@/pages/HashtagPage";
 import PrivacyPage from "@/pages/PrivacyPage";
@@ -120,6 +123,9 @@ function Router() {
         <Route path="/personalization" component={PersonalizationPage} />
         <Route path="/about" component={AboutPage} />
         <Route path="/developers" component={DevelopersPage} />
+        <Route path="/developers/nip-50" component={DeveloperNip50Page} />
+        <Route path="/developers/open-ranking" component={DeveloperOpenRankingPage} />
+        <Route path="/developers/trusted-assertions" component={DeveloperTrustedAssertionsPage} />
         <Route path="/nostr" component={NostrPage} />
         <Route path="/privacy" component={PrivacyPage} />
         <Route path="/terms" component={TermsPage} />

--- a/client/src/components/FlashIcon.tsx
+++ b/client/src/components/FlashIcon.tsx
@@ -1,5 +1,5 @@
-// Custom lightning/flash glyph (filled bolt with faded motion lines). Fills use
-// `currentColor`, so color it with a text-* class (e.g. text-yellow-400) and
+// Custom lightning/flash glyph (a clean filled bolt). Fill uses `currentColor`,
+// so color it with a text-* class (e.g. text-[#F7931A] for Bitcoin orange) and
 // size it with height/width utility classes like a lucide icon.
 export function FlashIcon({ className }: { className?: string }) {
   return (
@@ -10,10 +10,7 @@ export function FlashIcon({ className }: { className?: string }) {
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >
-      <path d="M8.62988 13H13.0299V21L21.8299 11H17.4299V3L8.62988 13Z" />
-      <path opacity="0.4" fillRule="evenodd" clipRule="evenodd" d="M0.75 3.25H9.25V4.75H0.75V3.25Z" />
-      <path opacity="0.4" fillRule="evenodd" clipRule="evenodd" d="M0.75 19.25H8.25V20.75H0.75V19.25Z" />
-      <path opacity="0.4" fillRule="evenodd" clipRule="evenodd" d="M0.75 11.25H5.25V12.75H0.75V11.25Z" />
+      <path d="M8.96221 23L10.3059 13.8357L4 11.6403L9.57648 1H17.7828L13.3773 8.73503L20 10.921L8.96221 23ZM6.0252 10.8556L11.8992 12.9015L11.0642 18.5907L17.4757 11.5749L11.2753 9.51975L15.3353 2.40127H10.4595L6.03479 10.8556H6.0252Z" />
     </svg>
   );
 }

--- a/client/src/components/WotStrengthCard.tsx
+++ b/client/src/components/WotStrengthCard.tsx
@@ -49,7 +49,7 @@ export function WotStrengthCard({
       <div className="flex items-center justify-between gap-1.5 mb-2">
         <span className="inline-flex items-center gap-1.5">
           <BrainLogo size={15} className="text-indigo-500" />
-          <span className="text-sm font-bold text-slate-900" style={{ fontFamily: "var(--font-display)" }}>Trust Score</span>
+          <span className="text-sm font-bold text-slate-900" style={{ fontFamily: "var(--font-display)" }}>Verification Score</span>
         </span>
         <PovTag pov={pov} />
       </div>

--- a/client/src/components/developers/DevShared.tsx
+++ b/client/src/components/developers/DevShared.tsx
@@ -1,0 +1,109 @@
+import { Link } from "wouter";
+import { Github, ExternalLink, ArrowLeft } from "lucide-react";
+
+// Shared building blocks for the /developers pages — the editorial card, the
+// custom glyphs, the back-link, and the open-source section — so the landing
+// and every per-method detail page share one look.
+
+export const FavoriteChartIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" className={className}>
+    <path d="M13 22.75H9C3.57 22.75 1.25 20.43 1.25 15V9C1.25 3.57 3.57 1.25 9 1.25H15C20.43 1.25 22.75 3.57 22.75 9V13C22.75 13.41 22.41 13.75 22 13.75C21.59 13.75 21.25 13.41 21.25 13V9C21.25 4.39 19.61 2.75 15 2.75H9C4.39 2.75 2.75 4.39 2.75 9V15C2.75 19.61 4.39 21.25 9 21.25H13C13.41 21.25 13.75 21.59 13.75 22C13.75 22.41 13.41 22.75 13 22.75Z" />
+    <path d="M7.33009 15.24C7.17009 15.24 7.0101 15.19 6.8701 15.08C6.5401 14.83 6.48012 14.36 6.73012 14.03L9.11009 10.94C9.40009 10.57 9.81011 10.33 10.2801 10.27C10.7501 10.21 11.2101 10.34 11.5801 10.63L13.4101 12.07C13.4801 12.13 13.5501 12.12 13.6001 12.12C13.6401 12.12 13.7101 12.1 13.7701 12.02L16.0801 9.04C16.3301 8.71 16.8001 8.65001 17.1301 8.91001C17.4601 9.16001 17.5201 9.63001 17.2601 9.96001L14.9501 12.94C14.6601 13.31 14.2501 13.55 13.7801 13.6C13.3201 13.66 12.8501 13.53 12.4901 13.24L10.6601 11.8C10.5901 11.74 10.5101 11.74 10.4701 11.75C10.4301 11.75 10.3601 11.77 10.3001 11.85L7.92012 14.94C7.78012 15.14 7.56009 15.24 7.33009 15.24Z" />
+    <path d="M20.26 22.7502C19.91 22.7502 19.46 22.6402 18.93 22.3202L18.68 22.1702C18.61 22.1302 18.3999 22.1302 18.3299 22.1702L18.0799 22.3202C16.9299 23.0102 16.2 22.7202 15.88 22.4802C15.55 22.2402 15.04 21.6402 15.34 20.3202L15.39 20.1102C15.41 20.0302 15.3499 19.8402 15.2999 19.7802L14.95 19.4302C14.36 18.8302 14.1299 18.1302 14.3299 17.5002C14.5299 16.8802 15.12 16.4402 15.95 16.3002L16.3299 16.2402C16.3999 16.2202 16.5399 16.1202 16.5799 16.0502L16.8599 15.4802C17.2499 14.6902 17.85 14.2402 18.51 14.2402C19.17 14.2402 19.77 14.6902 20.16 15.4802L20.44 16.0402C20.48 16.1102 20.62 16.2102 20.69 16.2302L21.07 16.2902C21.9 16.4302 22.49 16.8702 22.69 17.4902C22.89 18.1102 22.67 18.8102 22.07 19.4202L21.72 19.7702C21.67 19.8302 21.61 20.0202 21.63 20.1002L21.68 20.3102C21.98 21.6302 21.47 22.2302 21.14 22.4702C20.96 22.6102 20.67 22.7502 20.26 22.7502ZM18.49 15.7502C18.48 15.7602 18.34 15.8602 18.2 16.1502L17.92 16.7202C17.68 17.2102 17.1099 17.6302 16.5799 17.7202L16.2 17.7802C15.88 17.8302 15.77 17.9402 15.76 17.9602C15.76 17.9802 15.79 18.1402 16.02 18.3702L16.37 18.7202C16.78 19.1402 16.9899 19.8602 16.8599 20.4302L16.81 20.6402C16.72 21.0302 16.76 21.2002 16.78 21.2602C16.81 21.2402 16.98 21.2202 17.31 21.0202L17.56 20.8702C18.11 20.5402 18.9 20.5402 19.45 20.8702L19.7 21.0202C20.11 21.2702 20.28 21.2402 20.29 21.2402C20.25 21.2402 20.3 21.0402 20.21 20.6402L20.16 20.4302C20.03 19.8502 20.24 19.1402 20.65 18.7202L21 18.3702C21.23 18.1402 21.26 17.9802 21.26 17.9502C21.25 17.9302 21.14 17.8302 20.82 17.7702L20.44 17.7102C19.9 17.6202 19.34 17.2002 19.1 16.7102L18.82 16.1502C18.66 15.8502 18.52 15.7602 18.49 15.7502Z" />
+  </svg>
+);
+
+export const ConnectionIcon = ({ className }: { className?: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" className={className}>
+    <path d="M13.6405 10.36C14.5505 11.27 14.5505 12.74 13.6405 13.65C12.7305 14.56 11.2605 14.56 10.3505 13.65C9.44047 12.74 9.44047 11.27 10.3505 10.36C11.2605 9.44999 12.7305 9.44999 13.6405 10.36Z" />
+    <path d="M21.3904 10.52C22.2104 11.34 22.2104 12.66 21.3904 13.48C20.5704 14.3 19.2504 14.3 18.4304 13.48C17.6104 12.66 17.6104 11.34 18.4304 10.52C19.2504 9.69997 20.5704 9.69997 21.3904 10.52Z" />
+    <g opacity="0.4"><path d="M5.57012 10.52C6.39012 11.34 6.39012 12.66 5.57012 13.48C4.75012 14.3 3.43012 14.3 2.61012 13.48C1.79012 12.66 1.79012 11.34 2.61012 10.52C3.43012 9.69997 4.75012 9.69997 5.57012 10.52Z" /></g>
+    <g opacity="0.4"><path d="M17.4305 3.66999C18.2505 4.48999 18.2505 5.80999 17.4305 6.62999C16.6105 7.44999 15.2905 7.44999 14.4705 6.62999C13.6505 5.80999 13.6505 4.48999 14.4705 3.66999C15.2905 2.84999 16.6105 2.84999 17.4305 3.66999Z" /></g>
+    <path d="M9.53008 17.37C10.3501 18.19 10.3501 19.51 9.53008 20.33C8.71008 21.15 7.39008 21.15 6.57008 20.33C5.75008 19.51 5.75008 18.19 6.57008 17.37C7.39008 16.55 8.71008 16.55 9.53008 17.37Z" />
+    <path d="M9.53008 3.66999C10.3501 4.48999 10.3501 5.80999 9.53008 6.62999C8.71008 7.44999 7.39008 7.44999 6.57008 6.62999C5.75008 5.80999 5.75008 4.48999 6.57008 3.66999C7.39008 2.84999 8.71008 2.84999 9.53008 3.66999Z" />
+    <g opacity="0.4"><path d="M17.4305 17.37C18.2505 18.19 18.2505 19.51 17.4305 20.33C16.6105 21.15 15.2905 21.15 14.4705 20.33C13.6505 19.51 13.6505 18.19 14.4705 17.37C15.2905 16.55 16.6105 16.55 17.4305 17.37Z" /></g>
+    <g opacity="0.4"><path d="M9.09001 17.79C8.96001 17.79 8.83001 17.76 8.72001 17.69C8.36001 17.48 8.24001 17.02 8.45001 16.67L10.2 13.64C10.41 13.28 10.87 13.16 11.22 13.37C11.58 13.58 11.7 14.04 11.49 14.39L9.74001 17.42C9.60001 17.66 9.35001 17.8 9.09001 17.8V17.79Z" /></g>
+    <g opacity="0.4"><path d="M10.84 10.74C10.58 10.74 10.33 10.61 10.19 10.36L8.44001 7.33C8.23001 6.97 8.36001 6.51 8.71001 6.31C9.07001 6.1 9.53001 6.23 9.73001 6.58L11.48 9.61C11.69 9.97 11.56 10.43 11.21 10.63C11.09 10.7 10.96 10.73 10.84 10.73V10.74Z" /></g>
+    <g opacity="0.4"><path d="M17.8103 12.75H14.3203C13.9103 12.75 13.5703 12.41 13.5703 12C13.5703 11.59 13.9103 11.25 14.3203 11.25H17.8103C18.2203 11.25 18.5603 11.59 18.5603 12C18.5603 12.41 18.2203 12.75 17.8103 12.75Z" /></g>
+  </svg>
+);
+
+export function DevBackLink() {
+  return (
+    <Link
+      href="/developers"
+      className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-[#333286]"
+      data-testid="link-dev-back"
+    >
+      <ArrowLeft className="h-4 w-4" /> Developers
+    </Link>
+  );
+}
+
+export function SectionCard({
+  icon,
+  title,
+  children,
+  testId,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+  testId: string;
+}) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden" data-testid={testId}>
+      <div className="p-6 sm:p-8 space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-xl bg-[#7c86ff]/10 border border-[#7c86ff]/20 flex items-center justify-center shrink-0">
+            {icon}
+          </div>
+          <h2 className="text-xl font-bold text-slate-900 tracking-tight" style={{ fontFamily: "var(--font-display)" }}>
+            {title}
+          </h2>
+        </div>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export const GITHUB_REPOS: { label: string; description: string; href: string }[] = [
+  {
+    label: "NosFabrica",
+    description: "Brainstorm website, relay & personalization service",
+    href: "https://github.com/NosFabrica",
+  },
+];
+
+/** The shared open-source section (repo links), used on the landing. */
+export function OpenSourceSection() {
+  return (
+    <SectionCard icon={<Github className="h-5 w-5 text-[#333286]" />} title="Open-source" testId="card-dev-opensource">
+      <p className="text-[15px] text-slate-600 leading-relaxed">
+        Brainstorm is built in the open. Explore the code, file issues, or contribute:
+      </p>
+      <div className="flex flex-wrap gap-3">
+        {GITHUB_REPOS.map((repo) => (
+          <a
+            key={repo.label}
+            href={repo.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-flex items-center gap-3 rounded-xl bg-white border border-slate-200 hover:border-[#7c86ff]/40 hover:shadow-sm transition-all pl-3 pr-4 py-2.5"
+            data-testid={`link-github-${repo.label.toLowerCase().replace(/\s+/g, "-")}`}
+          >
+            <div className="h-9 w-9 rounded-lg bg-[#7c86ff]/10 border border-[#7c86ff]/20 flex items-center justify-center shrink-0">
+              <Github className="h-4 w-4 text-[#333286]" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-slate-900 whitespace-nowrap">{repo.label}</p>
+              <p className="text-xs text-slate-500 leading-snug whitespace-nowrap">{repo.description}</p>
+            </div>
+            <ExternalLink className="h-4 w-4 text-[#7c86ff] shrink-0 ml-1 group-hover:translate-x-0.5 transition-transform" />
+          </a>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}

--- a/client/src/components/score/TrustScorePov.tsx
+++ b/client/src/components/score/TrustScorePov.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { useActivePov } from "@/hooks/useActivePov";
 import { hasSessionToken } from "@/services/api";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 
 /**
  * The sitewide "whose view is this score?" system (team feedback):
@@ -53,17 +54,17 @@ export function PovIcon({ pov, className = "h-3 w-3" }: { pov: ScorePov; classNa
 export function PovTag({ pov }: { pov: ScorePov }) {
   return pov === "personalized" ? (
     <span className="inline-flex items-center gap-1 rounded-full bg-indigo-100/80 border border-indigo-200 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-600" data-testid="pov-tag">
-      <UserRound className="h-2.5 w-2.5" /> For you
+      <UserRound className="h-2.5 w-2.5" /> Personalized
     </span>
   ) : (
     <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 border border-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-500" data-testid="pov-tag">
-      <Globe className="h-2.5 w-2.5" /> Everyone
+      <Globe className="h-2.5 w-2.5" /> Global
     </span>
   );
 }
 
 /**
- * The shared Trust Score explainer + view switcher. Three jobs (per team
+ * The shared Verification Score explainer + view switcher. Three jobs (per team
  * feedback): explain what the score means, state whose view is shown NOW, and
  * toggle personalized ↔ global (app-wide, via the shared store). When a surface
  * can't serve both views, pass `unsupportedNote` — the toggle hides and an
@@ -74,10 +75,17 @@ export function TrustScoreModal({
   open,
   onOpenChange,
   unsupportedNote,
+  scores,
 }: {
   open: boolean;
   onOpenChange: (o: boolean) => void;
   unsupportedNote?: string;
+  /**
+   * This profile's score (0–1 influence) in each view, for the compare-both
+   * display. Optional — omitted on surfaces that just explain/toggle. A coin
+   * renders beside each option so the two perspectives sit side by side.
+   */
+  scores?: { personalized: number | null; global: number | null };
 }) {
   const { pov, loggedIn, setPersonalized } = useScorePov();
 
@@ -99,10 +107,10 @@ export function TrustScoreModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md" data-testid="trust-score-modal">
         <DialogHeader>
-          <DialogTitle>Trust Score</DialogTitle>
+          <DialogTitle>Verification Score</DialogTitle>
           <DialogDescription className="text-[13px] leading-relaxed">
-            A Trust Score (0–100) measures how trusted an account is, based on real people's
-            follows, mutes and reports — not an algorithm. The same account can score
+            A Verification Score (0–100) measures how verified an account is, based on real
+            people's follows, mutes and reports — not an algorithm. The same account can score
             differently depending on <span className="font-semibold text-slate-700">whose network</span>{" "}
             you look through.
           </DialogDescription>
@@ -136,7 +144,7 @@ export function TrustScoreModal({
               data-testid="pov-option-personalized"
             >
               <UserRound className="h-4 w-4 text-indigo-500 shrink-0 mt-0.5" />
-              <span className="min-w-0">
+              <span className="min-w-0 flex-1">
                 <span className="flex items-center gap-1.5 text-sm font-semibold text-slate-800">
                   Personalized — for you
                   {p.active && <span className="text-[10px] font-bold uppercase tracking-wide text-indigo-600">Current view</span>}
@@ -145,6 +153,9 @@ export function TrustScoreModal({
                   Seen through <span className="font-medium">your own</span> network — the people you trust, and who they trust.
                 </span>
               </span>
+              {scores && (
+                <VerificationCoin score01={scores.personalized} pov="personalized" size={34} ring={false} className="shrink-0 self-center" />
+              )}
             </button>
           )}
 
@@ -157,7 +168,7 @@ export function TrustScoreModal({
             data-testid="pov-option-global"
           >
             <Globe className="h-4 w-4 text-slate-400 shrink-0 mt-0.5" />
-            <span className="min-w-0">
+            <span className="min-w-0 flex-1">
               <span className="flex items-center gap-1.5 text-sm font-semibold text-slate-800">
                 Global — everyone
                 {g.active && <span className="text-[10px] font-bold uppercase tracking-wide text-slate-500">Current view</span>}
@@ -166,6 +177,9 @@ export function TrustScoreModal({
                 Brainstorm's network-wide view — the same number every visitor sees.
               </span>
             </span>
+            {scores && (
+              <VerificationCoin score01={scores.global} pov="global" size={34} ring={false} className="shrink-0 self-center" />
+            )}
           </button>
         </div>
 

--- a/client/src/components/score/VerificationCoin.tsx
+++ b/client/src/components/score/VerificationCoin.tsx
@@ -1,0 +1,100 @@
+import { TIER_THRESHOLDS, TRUST_TIER_COLORS } from "@/services/trustThreshold";
+import type { ScorePov } from "@/components/score/TrustScorePov";
+
+/**
+ * VerificationCoin — the sitewide, label-less Verification Score badge.
+ *
+ * A single round number-coin whose styling alone conveys three things (team
+ * design decisions):
+ *   1. that it IS a verification score  → the consistent coin shape + placement
+ *   2. personalized vs global           → SATURATION: personalized = colored,
+ *      global = flat grey (never boundary — unreadable at small sizes)
+ *   3. tier                             → the NUMBER always (0–100), reinforced
+ *      by HUE in the personalized (colored) view
+ *
+ * Deliberately unlabeled: the name "Verification Score" lives only in the
+ * explainer/modal, never on the coin. Reused everywhere (profile avatar corner,
+ * search rows, note cards, lists) so it's recognizable by shape alone.
+ */
+
+export type VerificationTier = "high" | "trusted" | "neutral" | "low" | "unverified";
+
+export function tierForScore01(score01: number): VerificationTier {
+  if (score01 >= TIER_THRESHOLDS.high) return "high";
+  if (score01 >= TIER_THRESHOLDS.medium_high) return "trusted";
+  if (score01 >= TIER_THRESHOLDS.medium) return "neutral";
+  if (score01 >= 0.02) return "low";
+  return "unverified";
+}
+
+// Personalized flavor: solid tier hue, white number. The lowest tier stays
+// gently COLORED (indigo-tinted), never pure grey — grey is reserved for global,
+// so the two flavors never collide at the bottom of the scale.
+const PERSONALIZED_FILL: Record<VerificationTier, string> = {
+  high: TRUST_TIER_COLORS.highlyTrusted, // emerald
+  trusted: TRUST_TIER_COLORS.trusted, // sky
+  neutral: TRUST_TIER_COLORS.neutral, // indigo
+  low: "#d97706", // amber-600 — darker than the shared bar amber for white-text contrast on the coin
+  unverified: "#c7d2fe", // indigo-200 — colored, not grey
+};
+
+// Global flavor: one neutral slate for every tier; the number carries the tier.
+const GLOBAL_FILL = "#64748b"; // slate-500
+
+// Fills light enough to need dark text instead of white.
+const DARK_TEXT_FILLS = new Set<string>(["#c7d2fe"]);
+
+export function VerificationCoin({
+  score01,
+  pov,
+  size = 44,
+  onClick,
+  className = "",
+  ring = true,
+}: {
+  /** Influence 0–1 (backend scale); rendered as 0–100. Null → unrated ("—"). */
+  score01: number | null | undefined;
+  pov: ScorePov;
+  size?: number;
+  onClick?: () => void;
+  className?: string;
+  /** Thin white ring to lift the coin off an avatar/background. */
+  ring?: boolean;
+}) {
+  const hasScore = typeof score01 === "number" && Number.isFinite(score01);
+  const clamped = hasScore ? Math.max(0, Math.min(1, score01 as number)) : 0;
+  const tier = tierForScore01(clamped);
+  const pct = Math.round(clamped * 100);
+
+  const fill = !hasScore ? "#e2e8f0" : pov === "personalized" ? PERSONALIZED_FILL[tier] : GLOBAL_FILL;
+  const darkText = !hasScore || DARK_TEXT_FILLS.has(fill);
+
+  const povLabel = pov === "personalized" ? "personalized" : "global";
+  const label = hasScore
+    ? `Verification score ${pct} out of 100, ${povLabel} view`
+    : `Unrated, ${povLabel} view`;
+
+  const Comp = onClick ? "button" : "div";
+  return (
+    <Comp
+      type={onClick ? "button" : undefined}
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={`inline-flex items-center justify-center rounded-full font-bold leading-none tabular-nums shadow-sm ${ring ? "ring-2 ring-white" : ""} ${onClick ? "transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400" : ""} ${className}`}
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: fill,
+        color: darkText ? "#1e293b" : "#ffffff",
+        fontFamily: "var(--font-display)",
+        fontSize: Math.round(size * 0.4),
+      }}
+      data-testid="verification-coin"
+      data-pov={pov}
+      data-tier={tier}
+    >
+      {hasScore ? pct : "—"}
+    </Comp>
+  );
+}

--- a/client/src/components/share/EmbeddedNoteCard.tsx
+++ b/client/src/components/share/EmbeddedNoteCard.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter";
 import { BadgeCheck } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { NoteContent } from "@/components/share/NoteContent";
-import { tierForScore } from "@/components/share/TrustScoreBadge";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 import { npubFromPubkey } from "@/lib/shareId";
 import { DefaultAvatarImg } from "@/components/share/DefaultAvatarImg";
 import type { MinimalEvent } from "@/lib/noteRefs";
@@ -45,9 +45,6 @@ export function EmbeddedNoteCard({
   let npub = "";
   try { npub = npubFromPubkey(event.pubkey); } catch { /* ignore */ }
 
-  const tier = typeof trustScore01 === "number" && Number.isFinite(trustScore01) ? tierForScore(trustScore01) : null;
-  const pct = tier ? Math.round(Math.max(0, Math.min(1, trustScore01 as number)) * 100) : null;
-
   const onClick = href
     ? (e: MouseEvent) => {
         if ((e.target as HTMLElement).closest("a, button, video, [data-noopen]")) return;
@@ -72,16 +69,8 @@ export function EmbeddedNoteCard({
           {author?.nip05 && <BadgeCheck className="h-3.5 w-3.5 text-sky-500 shrink-0" />}
         </a>
         <div className="ml-auto flex items-center gap-2 shrink-0">
-          {tier && (
-            <span
-              title={`${tier.name} · Web of Trust`}
-              className="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] font-bold tabular-nums leading-none"
-              style={{ color: tier.color, backgroundColor: `${tier.color}14`, borderColor: `${tier.color}33` }}
-              data-testid="comment-trust-pill"
-            >
-              <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tier.color }} />
-              {pct}
-            </span>
+          {typeof trustScore01 === "number" && Number.isFinite(trustScore01) && (
+            <VerificationCoin score01={trustScore01} pov="global" size={22} />
           )}
           <span className="text-xs text-slate-400">{ago(event.created_at)}</span>
         </div>

--- a/client/src/components/share/FollowedByRow.tsx
+++ b/client/src/components/share/FollowedByRow.tsx
@@ -4,6 +4,15 @@ import { DefaultAvatarImg } from "@/components/share/DefaultAvatarImg";
 
 export type FollowedByPerson = { pubkey: string; name?: string; picture?: string };
 
+// Compact count so the line stays a uniform width across users: 7,218 → 7.2k,
+// 1,234,567 → 1.2M; anything under 1,000 stays exact. Lowercase k, uppercase M.
+function compactCount(n: number): string {
+  if (n < 1000) return String(n);
+  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 })
+    .format(n)
+    .replace("K", "k");
+}
+
 /**
  * "Followed by [avatars] Alice, Bob & 1,234 others" — social proof from the
  * top WoT-ranked followers (the most-trusted accounts in the network who follow
@@ -19,9 +28,9 @@ export function FollowedByRow({ people, total, href, stacked = false }: { people
 
   const label =
     lead.length === 0
-      ? `Followed by ${grandTotal.toLocaleString()} trusted accounts`
+      ? `Followed by ${compactCount(grandTotal)} trusted accounts`
       : others > 0
-        ? `Followed by ${lead.join(", ")} & ${others.toLocaleString()} others`
+        ? `Followed by ${lead.join(", ")} & ${compactCount(others)} others`
         : `Followed by ${lead.join(" & ")}`;
 
   return (

--- a/client/src/components/share/ProfileActions.tsx
+++ b/client/src/components/share/ProfileActions.tsx
@@ -78,7 +78,7 @@ export function ProfileActions({
   };
 
   return (
-    <div className="flex items-center gap-2" data-testid="share-profile-actions">
+    <div className="flex flex-1 md:flex-none items-center gap-2" data-testid="share-profile-actions">
       <button
         type="button"
         onClick={toggleFollow}
@@ -104,7 +104,7 @@ export function ProfileActions({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="inline-flex h-9 w-9 md:h-8 md:w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-800 transition-colors"
+            className="inline-flex h-9 w-9 md:h-8 md:w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-800 transition-colors"
             aria-label="More actions"
             data-testid="share-actions-menu"
           >
@@ -146,5 +146,34 @@ export function ProfileActions({
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  );
+}
+
+/**
+ * The owner's own-profile overflow menu: no follow/mute/report (you can't act on
+ * yourself), just a ⋯ menu with the quiet "Advanced view" link — so the owner's
+ * controls look identical to everyone else's instead of a bare text link.
+ */
+export function OwnerActions({ npub }: { npub: string }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 md:h-8 md:w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-800 transition-colors"
+          aria-label="More actions"
+          data-testid="share-owner-menu"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem asChild className="gap-2 text-slate-500">
+          <Link href={`/profile/${npub}`} data-testid="share-advanced-view">
+            <ExternalLink className="h-4 w-4" /> Advanced view
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/client/src/components/share/ShareNoteCard.tsx
+++ b/client/src/components/share/ShareNoteCard.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, type MouseEvent } from "react";
 import { useLocation } from "wouter";
-import { Repeat2, MessageSquare, ShieldCheck } from "lucide-react";
+import { Repeat2, MessageSquare } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 import { tierForScore } from "@/components/share/TrustScoreBadge";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 import { NoteContent } from "@/components/share/NoteContent";
 import { parseNoteContent } from "@/lib/noteContent";
 import { EmbeddedNoteCard } from "@/components/share/EmbeddedNoteCard";
@@ -203,24 +204,15 @@ export function ShareNoteCard({
                   </span>
                   <div className="min-w-0">
                     <p className="text-sm font-bold leading-tight" style={{ color: authorTier.color }}>{authorTier.name}</p>
-                    <p className="text-[11px] text-slate-500">Web of Trust score</p>
+                    <p className="text-[11px] text-slate-500">Verification Score</p>
                   </div>
                 </div>
                 <p className="mt-2.5 text-[11px] leading-snug text-slate-400">Ranked into this topic by trusted accounts — not follower counts.</p>
               </HoverCardContent>
             )}
           </HoverCard>
-          {authorTier && typeof authorScore === "number" && (
-            <span
-              className="ml-auto inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[11px] font-bold tabular-nums"
-              style={{ color: authorTier.color, backgroundColor: `${authorTier.color}14`, borderWidth: 1, borderStyle: "solid", borderColor: `${authorTier.color}33` }}
-              title={`Web of Trust score — ${authorTier.name}`}
-              aria-label={`Web of Trust score ${Math.round(authorScore * 100)}, ${authorTier.name}`}
-              data-testid="note-author-score-chip"
-            >
-              <ShieldCheck className="h-3 w-3" />
-              {Math.round(authorScore * 100)}
-            </span>
+          {typeof authorScore === "number" && (
+            <VerificationCoin score01={authorScore} pov="global" size={24} className="ml-auto" />
           )}
           <span className="shrink-0 text-xs text-slate-400">{ago(event.created_at)}</span>
         </div>

--- a/client/src/components/share/StatToggle.tsx
+++ b/client/src/components/share/StatToggle.tsx
@@ -1,0 +1,78 @@
+import { Link } from "wouter";
+import { Eye } from "lucide-react";
+
+export type StatLens = "verified" | "all";
+
+/**
+ * One profile stat. The count + label is a LINK to the full list (click to
+ * browse). Which count it shows — "Verified" (web-of-trust filtered) or "All"
+ * (raw, includes bots) — is driven by a single shared `lens` toggle for the whole
+ * stats block (see StatLensToggle), so there's one clean control instead of a
+ * per-stat switch.
+ */
+export function Stat({
+  verified,
+  all,
+  verifiedLabel,
+  allLabel,
+  lens,
+  href,
+  danger = false,
+  testId,
+}: {
+  verified: number | null;
+  all: number | null;
+  verifiedLabel: string;
+  allLabel: string;
+  lens: StatLens;
+  href: string;
+  danger?: boolean;
+  testId?: string;
+}) {
+  const count = lens === "verified" ? verified : all;
+  const effective = count ?? (lens === "verified" ? all : verified);
+  if (effective == null) return null;
+
+  const label = lens === "verified" ? verifiedLabel : allLabel;
+  const numClass = danger ? "text-red-600" : "text-slate-700";
+  const labelClass = danger ? "text-red-500" : "";
+
+  return (
+    <Link
+      href={href}
+      className={`group/stat inline-flex items-center gap-1 transition-colors ${danger ? "hover:text-red-700" : "hover:text-slate-700"}`}
+      data-testid={testId}
+    >
+      <span className={`font-semibold tabular-nums ${numClass}`}>{effective.toLocaleString()}</span>
+      <span className={`border-b border-dotted border-transparent group-hover/stat:border-current/40 ${labelClass}`}>{label}</span>
+    </Link>
+  );
+}
+
+/**
+ * The single lens switch for the stats block — one quiet flip-link under the
+ * stats that toggles every count between verified (trust-filtered) and all (raw)
+ * at once. Deliberately understated (reads like a footnote, not a control) so it
+ * doesn't compete with the stats themselves.
+ */
+export function StatLensToggle({
+  value,
+  onChange,
+}: {
+  value: StatLens;
+  onChange: (v: StatLens) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(value === "verified" ? "all" : "verified")}
+      className="inline-flex items-center gap-1 text-[11px] text-slate-400 transition-colors hover:text-slate-600"
+      title={value === "verified" ? "Show all counts, including bots the web of trust filters out" : "Show only web-of-trust-verified counts"}
+      data-testid="stat-lens-toggle"
+      data-mode={value}
+    >
+      <Eye className="h-3 w-3 shrink-0" aria-hidden />
+      {value === "verified" ? "Show all" : "Show verified"}
+    </button>
+  );
+}

--- a/client/src/lib/skVault.ts
+++ b/client/src/lib/skVault.ts
@@ -1,0 +1,161 @@
+/**
+ * At-rest encryption for the persisted account secret key ("device-key wrap").
+ *
+ * The problem this solves: we used to write the raw secret key as plaintext hex
+ * into `localStorage`, so anything that can read localStorage (a rogue script/
+ * extension, a copied storage dump) got the key outright. This module wraps the
+ * key with a **non-extractable** AES-GCM key that lives in IndexedDB — the raw
+ * bytes of that wrapping key can never be read back out by JavaScript, even by
+ * code running in our own origin. localStorage then holds only ciphertext.
+ *
+ * Threat model (honest ceiling): this defeats anything that reads/exfiltrates
+ * `localStorage`. It does NOT defeat full in-origin code execution (an XSS that
+ * itself calls `crypto.subtle.decrypt`) or a forensic copy of the browser
+ * profile directory where the on-disk key material may be recoverable. No
+ * browser-resident key wins those — this is a large improvement over plaintext,
+ * not a claim of perfect secrecy.
+ *
+ * The ciphertext is bound to the account pubkey via AES-GCM additional
+ * authenticated data (AAD), so an envelope minted for one account cannot be
+ * silently decrypted under a different logged-in account — it fails closed.
+ *
+ * The decrypted key is NEVER written back to any storage API by this module;
+ * callers hold it in memory only. When IndexedDB / WebCrypto is unavailable
+ * (e.g. some private-browsing modes), `isVaultSupported()` returns false and the
+ * caller falls back to today's plaintext-persist behavior.
+ */
+
+const DB_NAME = "brainstorm-vault";
+const STORE = "keys";
+const DEVICE_KEY_ID = "device";
+const VERSION = "v1";
+
+/** Secure context + IndexedDB + WebCrypto all present. */
+export function isVaultSupported(): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof indexedDB !== "undefined" &&
+      !!window.isSecureContext &&
+      typeof crypto !== "undefined" &&
+      !!crypto.subtle
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ---- base64 (binary-safe) ----------------------------------------------------
+function b64encode(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function b64decode(s: string): Uint8Array {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// ---- IndexedDB (tiny promise wrapper, no external dep) -----------------------
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbGet(key: string): Promise<unknown> {
+  return openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, "readonly");
+        const req = tx.objectStore(STORE).get(key);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+        tx.oncomplete = () => db.close();
+      }),
+  );
+}
+
+function idbPut(key: string, val: unknown): Promise<void> {
+  return openDb().then(
+    (db) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE, "readwrite");
+        tx.objectStore(STORE).put(val, key);
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => reject(tx.error);
+      }),
+  );
+}
+
+// ---- device key --------------------------------------------------------------
+// Non-extractable AES-GCM key, created lazily and reused for the life of the
+// device. It's a device secret, not an account secret — it persists across
+// logout/login and account switches (logout wipes the ciphertext it unlocks, so
+// the key alone is inert). Cached as a promise so repeated ops don't re-open IDB.
+let deviceKeyPromise: Promise<CryptoKey> | null = null;
+
+function getDeviceKey(): Promise<CryptoKey> {
+  if (!deviceKeyPromise) {
+    deviceKeyPromise = (async () => {
+      const existing = await idbGet(DEVICE_KEY_ID);
+      if (existing) return existing as CryptoKey;
+      const key = await crypto.subtle.generateKey(
+        { name: "AES-GCM", length: 256 },
+        false, // non-extractable — raw bytes never exposed to JS
+        ["encrypt", "decrypt"],
+      );
+      await idbPut(DEVICE_KEY_ID, key);
+      return key;
+    })().catch((err) => {
+      deviceKeyPromise = null; // let a later call retry
+      throw err;
+    });
+  }
+  return deviceKeyPromise;
+}
+
+// ---- public API --------------------------------------------------------------
+/**
+ * Encrypt `secret` (the raw secret-key bytes) into a versioned envelope string
+ * `v1:<base64 iv>:<base64 ciphertext>`, bound to `pubkeyHex` via AAD. Throws if
+ * the vault is unavailable — callers gate on `isVaultSupported()` and fall back.
+ */
+export async function encryptSecret(secret: Uint8Array, pubkeyHex: string): Promise<string> {
+  const key = await getDeviceKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const aad = new TextEncoder().encode(pubkeyHex);
+  const ct = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv, additionalData: aad }, key, secret),
+  );
+  return `${VERSION}:${b64encode(iv)}:${b64encode(ct)}`;
+}
+
+/**
+ * Decrypt an envelope produced by `encryptSecret`, verifying it was minted for
+ * `pubkeyHex` (AAD). Throws on a bad/foreign/corrupt envelope or wrong account —
+ * callers treat a throw as "no usable key" (re-login).
+ */
+export async function decryptSecret(envelope: string, pubkeyHex: string): Promise<Uint8Array> {
+  const parts = envelope.split(":");
+  if (parts.length !== 3 || parts[0] !== VERSION) {
+    throw new Error("skVault: unrecognized envelope format");
+  }
+  const iv = b64decode(parts[1]);
+  const ct = b64decode(parts[2]);
+  const key = await getDeviceKey();
+  const aad = new TextEncoder().encode(pubkeyHex);
+  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv, additionalData: aad }, key, ct);
+  return new Uint8Array(pt);
+}

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1918,15 +1918,8 @@ export default function AdminPage() {
 
   const overviewActivityQuery = useQuery<AdminUserHistoryPage>({
     queryKey: ["/api/admin/activity/overview"],
-    // Pull more history so the 7d/30d trends are meaningful; fall back to a
-    // smaller page if the endpoint caps the size.
-    queryFn: async () => {
-      try {
-        return await apiClient.getAdminActivity({ page: 1, size: 500 });
-      } catch {
-        return await apiClient.getAdminActivity({ page: 1, size: 100 });
-      }
-    },
+    // Backend caps `size` at 100; requesting more 422s.
+    queryFn: () => apiClient.getAdminActivity({ page: 1, size: 100 }),
     enabled: !!user,
     staleTime: 60_000,
     retry: 1,

--- a/client/src/pages/ArticlePage.tsx
+++ b/client/src/pages/ArticlePage.tsx
@@ -7,7 +7,7 @@ import rehypeSanitize from "rehype-sanitize";
 import { nip19 } from "nostr-tools";
 import { ArrowLeft, ArrowRight, BadgeCheck, Smartphone, Loader2, FileText } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { tierForScore } from "@/components/share/TrustScoreBadge";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 import { fetchAddressableEvents, fetchProfile } from "@/services/nostr";
 import { apiClient, hasSessionToken } from "@/services/api";
 import { openArticleInApp } from "@/lib/articleLinks";
@@ -91,7 +91,6 @@ export default function ArticlePage() {
   const authorName = profile.display_name || profile.name || (ptr ? nip19.npubEncode(ptr.pubkey).slice(0, 12) + "…" : "Unknown");
   const authorNpub = ptr ? (() => { try { return npubFromPubkey(ptr.pubkey); } catch { return ""; } })() : "";
   const score01 = typeof trustQuery.data === "number" ? trustQuery.data : null;
-  const tier = score01 != null ? tierForScore(score01) : null;
   const loggedIn = hasSessionToken();
   const firstName = authorName.split(" ")[0];
   const [threadGated, setThreadGated] = useState(false);
@@ -167,15 +166,8 @@ export default function ArticlePage() {
                   <span className="text-xs text-slate-400">{publishedAgo(ev)}</span>
                 </div>
               </Link>
-              {tier && (
-                <span
-                  className="ml-auto shrink-0 inline-flex items-center gap-1.5 rounded-full border pl-1.5 pr-2.5 py-1 text-[11px] font-bold uppercase tracking-wide"
-                  style={{ color: tier.color, backgroundColor: `${tier.color}14`, borderColor: `${tier.color}55` }}
-                  title="Network web-of-trust score"
-                >
-                  <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tier.color }} />
-                  {tier.name} · {Math.round((score01 ?? 0) * 100)}
-                </span>
+              {typeof score01 === "number" && Number.isFinite(score01) && (
+                <VerificationCoin score01={score01} pov="global" size={24} className="ml-auto" />
               )}
             </div>
 

--- a/client/src/pages/ConnectionListPage.tsx
+++ b/client/src/pages/ConnectionListPage.tsx
@@ -8,12 +8,12 @@ import { REPORT_TYPE_BADGE_COLORS, formatReportTime } from "@/lib/reportMeta";
 import { apiClient, hasSessionToken } from "@/services/api";
 import { getVerifiedThreshold } from "@/services/trustThreshold";
 import { toPubkeys, toInfluenceMap, type GraphEntry } from "@/services/graphHelpers";
-import { tierForScore } from "@/components/share/TrustScoreBadge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { BrainLogo } from "@/components/BrainLogo";
 import { DefaultAvatarImg } from "@/components/share/DefaultAvatarImg";
 import { InfoHint } from "@/components/InfoHint";
-import { TrustScoreModal, PovIcon, useScorePov } from "@/components/score/TrustScorePov";
+import { TrustScoreModal, useScorePov, type ScorePov } from "@/components/score/TrustScorePov";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 
 type ConnKind = "followed_by" | "following" | "muted_by" | "reported_by";
 
@@ -265,7 +265,6 @@ export default function ConnectionListPage() {
               const name = p?.display_name || p?.name || (rowNpub ? rowNpub.slice(0, 12) + "…" : pk.slice(0, 12) + "…");
               const handle = cleanNip05(p?.nip05);
               const score = typeof inf === "number" ? Math.min(1, Math.max(0, inf)) : null;
-              const tier = score != null ? tierForScore(score) : null;
               return (
                 <Link
                   key={pk}
@@ -273,7 +272,7 @@ export default function ConnectionListPage() {
                   className="group flex items-center gap-3.5 px-4 py-3 hover:bg-slate-50 transition-colors"
                   data-testid={`conn-row-${pk.slice(0, 8)}`}
                 >
-                  <TrustAvatar picture={p?.picture} name={name} score={score} tier={tier} />
+                  <TrustAvatar picture={p?.picture} name={name} score={score} pov={scorePov} />
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-semibold text-slate-900">{name}</p>
                     {handle ? (
@@ -295,19 +294,6 @@ export default function ConnectionListPage() {
                       );
                     })()}
                   </div>
-                  {tier && (
-                    <button
-                      type="button"
-                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); setScoreExplainOpen(true); }}
-                      className={`hidden shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold sm:inline-flex ${scorePov === "personalized" ? "border-indigo-200" : "border-slate-200"}`}
-                      style={{ backgroundColor: `${tier.color}14`, color: tier.color }}
-                      title="What does this score mean?"
-                      data-testid="conn-tier"
-                    >
-                      <PovIcon pov={scorePov} className="h-2.5 w-2.5" />
-                      {tier.name}
-                    </button>
-                  )}
                   <ChevronRight className="h-4 w-4 shrink-0 text-slate-300 transition-colors group-hover:text-slate-400" />
                 </Link>
               );
@@ -336,19 +322,17 @@ export default function ConnectionListPage() {
 /** Avatar wrapped in a tier-coloured trust ring with a small score badge — one
  *  premium "person" token (LinkedIn/Facebook feel) instead of two side-by-side
  *  circles. */
-function TrustAvatar({ picture, name, score, tier }: { picture?: string; name: string; score: number | null; tier: { name: string; color: string } | null }) {
-  const pct = score != null ? Math.round(score * 100) : null;
+function TrustAvatar({ picture, name, score, pov }: { picture?: string; name: string; score: number | null; pov: ScorePov }) {
   return (
-    <div className="relative shrink-0" title={tier && pct != null ? `${tier.name} · ${pct}` : undefined}>
-      <Avatar
-        className="h-12 w-12 rounded-full bg-white"
-        style={{ boxShadow: tier ? `0 0 0 2px #fff, 0 0 0 4px ${tier.color}` : "0 0 0 1px #e2e8f0" }}
-      >
+    <div className="relative shrink-0">
+      <Avatar className="h-12 w-12 rounded-full bg-white" style={{ boxShadow: "0 0 0 1px #e2e8f0" }}>
         {picture ? <AvatarImage src={picture} alt={name} className="object-cover" /> : null}
         <AvatarFallback className="overflow-hidden rounded-full"><DefaultAvatarImg /></AvatarFallback>
       </Avatar>
-      {pct != null && tier && (
-        <span className="absolute -bottom-1 -right-1 rounded-full px-1.5 py-px text-[10px] font-bold tabular-nums text-white shadow-sm ring-2 ring-white" style={{ backgroundColor: tier.color }}>{pct}</span>
+      {/* The Verification Score coin — same label-less badge as the profile hero,
+          POV-aware (colored personalized / grey global). */}
+      {score != null && (
+        <VerificationCoin score01={score} pov={pov} size={24} className="absolute -bottom-1 -right-1" />
       )}
     </div>
   );

--- a/client/src/pages/DeveloperNip50Page.tsx
+++ b/client/src/pages/DeveloperNip50Page.tsx
@@ -1,0 +1,173 @@
+import { copyToClipboard } from "@/lib/clipboard";
+import { env } from "@/lib/runtimeEnv";
+import { useLocation } from "wouter";
+import { Terminal, Copy, ArrowRight } from "lucide-react";
+import { InfoPageLayout } from "@/components/InfoPageLayout";
+import { CodeBlock } from "@/components/CodeBlock";
+import { BrainLogo } from "@/components/BrainLogo";
+import { useToast } from "@/hooks/use-toast";
+import { SectionCard, ConnectionIcon, FavoriteChartIcon, OpenSourceSection, DevBackLink } from "@/components/developers/DevShared";
+
+// Per-env public search relay; no in-source fallback (see runtimeEnv).
+const RELAY_URL = env.VITE_WOT_SEARCH_RELAY;
+
+const QUICK_START_SNIPPET = `["REQ", "search-1", {
+  "kinds": [0],
+  "search": "jack"
+}]`;
+
+const PERSONALIZED_SNIPPET = `["REQ", "search-1", {
+  "kinds": [0],
+  "limit": 20,
+  "search": "jack observer:<your-pubkey> sort:followers:desc filter:rank:gte:2"
+}]`;
+
+const EXTENSIONS: { name: string; format: string; description: string }[] = [
+  {
+    name: "observer",
+    format: "observer:<hex-pubkey>",
+    description:
+      "The user's pubkey. Results are processed by that user's community. Omit to use the relay's default point of view.",
+  },
+  {
+    name: "sort",
+    format: "sort:<metric>:<asc|desc>",
+    description: "Sort by a trust metric. Common metrics: followers, rank",
+  },
+  {
+    name: "filter",
+    format: "filter:<metric>:<op>:<value>",
+    description: "Filter by a trust metric threshold. Operators: gte, lte, gt, lt, eq",
+  },
+];
+
+export default function DeveloperNip50Page() {
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+
+  const copyRelay = async () => {
+    try {
+      await copyToClipboard(RELAY_URL);
+      toast({ title: "Copied!", description: "Relay URL copied to clipboard" });
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  return (
+    <InfoPageLayout testId="page-developers-nip50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+        <div className="space-y-10 animate-fade-up">
+          {/* Editorial hero */}
+          <header className="max-w-3xl" data-testid="section-dev-header">
+            <div className="mb-5"><DevBackLink /></div>
+            <div className="flex items-center gap-2.5 mb-5">
+              <span className="text-[11px] font-mono font-semibold tracking-[0.25em] text-[#7c86ff] uppercase">
+                NIP-50 relay search
+              </span>
+              <div className="h-px w-12 bg-[#7c86ff]/40" />
+            </div>
+            <h1
+              className="text-4xl sm:text-5xl font-bold text-slate-900 tracking-tight leading-[1.08]"
+              style={{ fontFamily: "var(--font-display)" }}
+              data-testid="text-dev-title"
+            >
+              Add Brainstorm Search to <span className="text-[#333286]">your nostr client</span>.
+            </h1>
+            <p className="mt-5 text-lg text-slate-600 leading-relaxed max-w-2xl" data-testid="text-dev-subtitle">
+              This relay supports NIP-50 full-text profile search. Any nostr client can query it over a
+              standard WebSocket connection.
+            </p>
+          </header>
+
+          {/* Relay URL */}
+          <SectionCard icon={<ConnectionIcon className="h-5 w-5 text-[#333286]" />} title="Relay URL" testId="card-dev-relay">
+            <div className="flex items-center gap-2 rounded-xl bg-slate-50 border border-slate-200 px-4 py-3">
+              <code className="flex-1 font-mono text-[14px] text-indigo-700 break-all" data-testid="text-relay-url">
+                {RELAY_URL}
+              </code>
+              <button
+                type="button"
+                onClick={copyRelay}
+                className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[12px] font-medium text-slate-600 bg-white hover:bg-slate-100 border border-slate-200 shadow-sm transition-colors shrink-0"
+                data-testid="button-copy-relay"
+              >
+                <Copy className="h-3.5 w-3.5" />
+                Copy
+              </button>
+            </div>
+          </SectionCard>
+
+          {/* Quick Start */}
+          <SectionCard icon={<Terminal className="h-5 w-5 text-[#333286]" />} title="Quick Start" testId="card-dev-quickstart">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Connect via WebSocket and send a standard NIP-50 search REQ:
+            </p>
+            <CodeBlock code={QUICK_START_SNIPPET} testId="quickstart" />
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              This returns kind 0 profile events filtered and sorted by the community of the relay's default
+              nostr profile. All standard nostr traffic (non-search REQs, EVENT publishing) passes through to
+              the underlying strfry relay transparently.
+            </p>
+          </SectionCard>
+
+          {/* Personalized Results */}
+          <SectionCard icon={<BrainLogo size={20} className="text-[#333286]" />} title="Personalized Results with WoT Extensions" testId="card-dev-personalized">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Add custom extensions to the search string to get results personalized to a specific user
+              (filtered and sorted by that user's community):
+            </p>
+            <CodeBlock code={PERSONALIZED_SNIPPET} testId="personalized" />
+
+            <div className="overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-left border-collapse" data-testid="table-extensions">
+                <thead>
+                  <tr className="bg-slate-50">
+                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">Extension</th>
+                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">Format</th>
+                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {EXTENSIONS.map((ext) => (
+                    <tr key={ext.name} className="border-t border-slate-100 align-top" data-testid={`row-extension-${ext.name}`}>
+                      <td className="px-4 py-3"><code className="font-mono text-[13px] font-semibold text-indigo-600">{ext.name}</code></td>
+                      <td className="px-4 py-3"><code className="font-mono text-[13px] text-slate-700 whitespace-nowrap">{ext.format}</code></td>
+                      <td className="px-4 py-3 text-[14px] text-slate-600 leading-relaxed min-w-[200px]">{ext.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </SectionCard>
+
+          {/* Automatic Score Provisioning */}
+          <SectionCard icon={<FavoriteChartIcon className="h-5 w-5 text-[#333286]" />} title="Automatic Score Provisioning" testId="card-dev-provisioning">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              The first time you search with a new observer, the relay automatically loads that user's
+              Brainstorm data in the background if it is available. In the meantime, the search returns
+              results using the relay's default perspective. Once loaded, subsequent searches will return
+              results that are fully personalized.
+            </p>
+          </SectionCard>
+
+          {/* Cross-link */}
+          <button
+            onClick={() => navigate("/how-search-works")}
+            className="group w-full text-left rounded-2xl border border-slate-200 bg-white hover:border-[#7c86ff]/40 hover:shadow-sm transition-all p-6 flex items-center justify-between gap-4"
+            data-testid="link-to-how-search-works"
+          >
+            <div>
+              <p className="text-[11px] font-mono font-semibold tracking-[0.2em] text-[#7c86ff] uppercase mb-1.5">Keep reading</p>
+              <p className="text-base font-semibold text-slate-900">Want the bigger picture on how trust ranking works?</p>
+              <p className="text-sm text-slate-500 mt-0.5">See How Search Works</p>
+            </div>
+            <ArrowRight className="h-5 w-5 text-[#7c86ff] shrink-0 group-hover:translate-x-1 transition-transform" />
+          </button>
+
+          <OpenSourceSection />
+        </div>
+      </div>
+    </InfoPageLayout>
+  );
+}

--- a/client/src/pages/DeveloperOpenRankingPage.tsx
+++ b/client/src/pages/DeveloperOpenRankingPage.tsx
@@ -1,0 +1,165 @@
+import { env } from "@/lib/runtimeEnv";
+import { Compass, BarChart3, Search, Settings2, BookOpen } from "lucide-react";
+import { InfoPageLayout } from "@/components/InfoPageLayout";
+import { CodeBlock } from "@/components/CodeBlock";
+import { SectionCard, OpenSourceSection, DevBackLink } from "@/components/developers/DevShared";
+
+// Configurable Open Ranking (ORE) base — the HTTP origin that serves this
+// instance's ranking endpoints. Driven by config so it points at OUR deployment.
+// NOTE (confirm with the team): this documents live endpoints
+// (/.well-known/open-ranking.json, /stats/pubkey, /search/pubkeys). If our
+// instance doesn't serve ORE yet, this page is accurate-but-aspirational until it does.
+const ORE_BASE = (env.VITE_API_URL || "https://your-brainstorm-instance").replace(/\/+$/, "");
+
+const STATS_CURL = `curl -s -X POST ${ORE_BASE}/stats/pubkey \\
+  -H 'Content-Type: application/json' \\
+  -d '{"pubkey":"<64-hex-pubkey>"}'`;
+
+const STATS_RESPONSE = `{
+  "pubkey": "<64-hex-pubkey>",
+  "rank": 93,
+  "hops": 1,
+  "followers": 19470,
+  "muters": 72,
+  "reporters": 6,
+  "follows": 1669,
+  "mutes": 0,
+  "reporting": 23,
+  "pagerank": 0.0114
+}`;
+
+const SEARCH_CURL = `curl -s -X POST ${ORE_BASE}/search/pubkeys \\
+  -H 'Content-Type: application/json' \\
+  -d '{"query":"jack","limit":20}'`;
+
+const SEARCH_RESPONSE = `{
+  "results": [
+    { "pubkey": "<hex>", "rank": 100 },
+    { "pubkey": "<hex>", "rank": 98 }
+  ]
+}`;
+
+const STATS_FIELDS: { field: string; meaning: string }[] = [
+  { field: "rank", meaning: "GrapeRank web-of-trust rank (GrapeRank influence ×100)." },
+  { field: "hops", meaning: "Degrees of separation along the follow graph from the point of view (999 = unreachable)." },
+  { field: "followers / muters / reporters", meaning: "Verified inbound counts — accounts following / muting / reporting this pubkey whose own web-of-trust rank clears the verification cutoff." },
+  { field: "follows / mutes / reporting", meaning: "Exact outbound totals — accounts this pubkey follows / mutes / has reported." },
+  { field: "pagerank", meaning: "Raw personalized-PageRank score under the active point of view." },
+];
+
+export default function DeveloperOpenRankingPage() {
+  return (
+    <InfoPageLayout testId="page-developers-open-ranking">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+        <div className="space-y-10 animate-fade-up">
+          {/* Editorial hero */}
+          <header className="max-w-3xl">
+            <div className="mb-5"><DevBackLink /></div>
+            <div className="flex items-center gap-2.5 mb-5">
+              <span className="text-[11px] font-mono font-semibold tracking-[0.25em] text-[#7c86ff] uppercase">
+                Open Ranking (ORE)
+              </span>
+              <div className="h-px w-12 bg-[#7c86ff]/40" />
+            </div>
+            <h1
+              className="text-4xl sm:text-5xl font-bold text-slate-900 tracking-tight leading-[1.08]"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              The web of trust over <span className="text-[#333286]">plain HTTP</span>.
+            </h1>
+            <p className="mt-5 text-lg text-slate-600 leading-relaxed max-w-2xl">
+              This instance is an Open Ranking provider — a plain HTTP/JSON interface to its web of trust. Any
+              HTTP client can discover its capabilities and query web-of-trust ranking, per-pubkey stats, and
+              profile search without speaking the nostr relay protocol. It complements the NIP-50 relay over
+              the same underlying data.
+            </p>
+          </header>
+
+          {/* 1. Discover capabilities */}
+          <SectionCard icon={<Compass className="h-5 w-5 text-[#333286]" />} title="1 · Discover capabilities" testId="card-ore-discover">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Fetch the capability document (<code className="font-mono text-[13px] text-indigo-600">GET</code>) to see which
+              endpoints and algorithms this provider offers:
+            </p>
+            <CodeBlock code={`${ORE_BASE}/.well-known/open-ranking.json`} testId="ore-well-known" />
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              It returns a JSON object keyed by endpoint path; each value lists the available algorithms. The
+              first algorithm in a list is that endpoint's default; an algorithm with{" "}
+              <code className="font-mono text-[13px] text-indigo-600">"pov": true</code> requires a point-of-view pubkey in the request.
+            </p>
+          </SectionCard>
+
+          {/* 2. Stats */}
+          <SectionCard icon={<BarChart3 className="h-5 w-5 text-[#333286]" />} title="2 · Web-of-trust stats" testId="card-ore-stats">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              <code className="font-mono text-[13px] font-semibold text-indigo-600">POST /stats/pubkey</code> — returns this
+              instance's web-of-trust metrics for one pubkey. Algorithms:{" "}
+              <code className="font-mono text-[13px] text-slate-700">graperank</code> (global, the default) and{" "}
+              <code className="font-mono text-[13px] text-slate-700">graperank-personalized</code> (requires a provisioned
+              pov; an unprovisioned one returns 422).
+            </p>
+            <CodeBlock code={STATS_CURL} testId="ore-stats-curl" />
+            <p className="text-[15px] text-slate-600 leading-relaxed">Response:</p>
+            <CodeBlock code={STATS_RESPONSE} testId="ore-stats-response" />
+            <div className="overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="bg-slate-50">
+                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">Field</th>
+                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">Meaning</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {STATS_FIELDS.map((f) => (
+                    <tr key={f.field} className="border-t border-slate-100 align-top">
+                      <td className="px-4 py-3"><code className="font-mono text-[13px] font-semibold text-indigo-600 whitespace-nowrap">{f.field}</code></td>
+                      <td className="px-4 py-3 text-[14px] text-slate-600 leading-relaxed min-w-[220px]">{f.meaning}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </SectionCard>
+
+          {/* 3. Search */}
+          <SectionCard icon={<Search className="h-5 w-5 text-[#333286]" />} title="3 · Profile search" testId="card-ore-search">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              <code className="font-mono text-[13px] font-semibold text-indigo-600">POST /search/pubkeys</code> — free-text
+              profile search, returning pubkeys ranked by this instance's global GrapeRank, highest first.
+            </p>
+            <CodeBlock code={SEARCH_CURL} testId="ore-search-curl" />
+            <p className="text-[15px] text-slate-600 leading-relaxed">Response:</p>
+            <CodeBlock code={SEARCH_RESPONSE} testId="ore-search-response" />
+          </SectionCard>
+
+          {/* Conventions */}
+          <SectionCard icon={<Settings2 className="h-5 w-5 text-[#333286]" />} title="Conventions" testId="card-ore-conventions">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              All endpoints are JSON over HTTP with{" "}
+              <code className="font-mono text-[13px] text-slate-700">Access-Control-Allow-Origin: *</code>. Pubkeys are
+              64-character lowercase hex. Errors are signalled by HTTP status —{" "}
+              <code className="font-mono text-[13px] text-slate-700">400</code> (malformed JSON),{" "}
+              <code className="font-mono text-[13px] text-slate-700">422</code> (invalid input / unsupported algorithm /
+              missing or unprovisioned pov) — with a human-readable{" "}
+              <code className="font-mono text-[13px] text-slate-700">X-Reason</code> header.
+            </p>
+          </SectionCard>
+
+          {/* Reference */}
+          <SectionCard icon={<BookOpen className="h-5 w-5 text-[#333286]" />} title="Reference" testId="card-ore-reference">
+            <ul className="space-y-2 text-[15px] text-slate-600 leading-relaxed list-disc pl-5">
+              <li>
+                Open Ranking protocol spec — <span className="font-mono text-[13px]">ORE-01</span> (discovery),{" "}
+                <span className="font-mono text-[13px]">ORE-02</span> (stats),{" "}
+                <span className="font-mono text-[13px]">ORE-05</span> (search)
+              </li>
+              <li>Brainstorm Search repo — this provider's implementation</li>
+            </ul>
+          </SectionCard>
+
+          <OpenSourceSection />
+        </div>
+      </div>
+    </InfoPageLayout>
+  );
+}

--- a/client/src/pages/DeveloperTrustedAssertionsPage.tsx
+++ b/client/src/pages/DeveloperTrustedAssertionsPage.tsx
@@ -1,0 +1,78 @@
+import { BadgeCheck, ExternalLink } from "lucide-react";
+import { env } from "@/lib/runtimeEnv";
+import { InfoPageLayout } from "@/components/InfoPageLayout";
+import { CodeBlock } from "@/components/CodeBlock";
+import { SectionCard, OpenSourceSection, DevBackLink } from "@/components/developers/DevShared";
+
+const NIP85_URL = "https://github.com/nostr-protocol/nips/blob/master/85.md";
+const NIP85_RELAY = (env.VITE_NIP85_RELAY_URL || "").trim().replace(/\/+$/, "");
+
+export default function DeveloperTrustedAssertionsPage() {
+  return (
+    <InfoPageLayout testId="page-developers-trusted-assertions">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+        <div className="space-y-10 animate-fade-up">
+          {/* Editorial hero */}
+          <header className="max-w-3xl">
+            <div className="mb-5"><DevBackLink /></div>
+            <div className="flex items-center gap-2.5 mb-5">
+              <span className="text-[11px] font-mono font-semibold tracking-[0.25em] text-[#7c86ff] uppercase">
+                Trusted Assertions · NIP-85
+              </span>
+              <div className="h-px w-12 bg-[#7c86ff]/40" />
+            </div>
+            <h1
+              className="text-4xl sm:text-5xl font-bold text-slate-900 tracking-tight leading-[1.08]"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              Portable scores, as <span className="text-[#333286]">signed nostr events</span>.
+            </h1>
+            <p className="mt-5 text-lg text-slate-600 leading-relaxed max-w-2xl">
+              Web-of-trust scores published as ordinary nostr events, so any client can fetch and verify them.
+            </p>
+          </header>
+
+          <SectionCard icon={<BadgeCheck className="h-5 w-5 text-[#333286]" />} title="How it works" testId="card-ta-overview">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Trusted Assertions are{" "}
+              <code className="font-mono text-[13px] text-indigo-600">kind 30382</code> nostr events carrying web-of-trust
+              scores — rank, verified follower counts, and related metrics — published by a trust authority about
+              other pubkeys.
+            </p>
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Because they are ordinary signed nostr events, any client can fetch them, verify who signed them, and
+              apply its own trust perspective without depending on this instance.
+            </p>
+            <a
+              href={NIP85_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-[15px] font-medium text-[#333286] hover:underline"
+              data-testid="link-nip85-spec"
+            >
+              Read about Trusted Assertions in the NIP-85 specification
+              <ExternalLink className="h-4 w-4" />
+            </a>
+            <p className="pt-2 text-[13px] text-slate-400">Documentation coming soon.</p>
+          </SectionCard>
+
+          <SectionCard icon={<BadgeCheck className="h-5 w-5 text-[#333286]" />} title="Where to find them" testId="card-ta-fetch">
+            <p className="text-[15px] text-slate-600 leading-relaxed">
+              Query <code className="font-mono text-[13px] text-indigo-600">kind 30382</code> events from this
+              instance's NIP-85 relay, authored by its trust-authority pubkey. See the NIP-85 spec for the tag
+              structure.
+            </p>
+            {NIP85_RELAY && (
+              <>
+                <p className="text-[15px] text-slate-600 leading-relaxed">NIP-85 relay:</p>
+                <CodeBlock code={NIP85_RELAY} testId="ta-relay" />
+              </>
+            )}
+          </SectionCard>
+
+          <OpenSourceSection />
+        </div>
+      </div>
+    </InfoPageLayout>
+  );
+}

--- a/client/src/pages/DevelopersPage.tsx
+++ b/client/src/pages/DevelopersPage.tsx
@@ -1,157 +1,45 @@
-import { useState } from "react";
-import { copyToClipboard } from "@/lib/clipboard";
-import { env } from "@/lib/runtimeEnv";
-import { useLocation } from "wouter";
-import {
-  Terminal,
-  Github,
-  ExternalLink,
-  Copy,
-  Check,
-  ArrowRight,
-} from "lucide-react";
+import { Link } from "wouter";
+import { ArrowRight, BadgeCheck } from "lucide-react";
 import { InfoPageLayout } from "@/components/InfoPageLayout";
-import { CodeBlock } from "@/components/CodeBlock";
-import { BrainLogo } from "@/components/BrainLogo";
-import { useToast } from "@/hooks/use-toast";
+import { ConnectionIcon, FavoriteChartIcon, OpenSourceSection } from "@/components/developers/DevShared";
 
-const FavoriteChartIcon = ({ className }: { className?: string }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    className={className}
-  >
-    <path d="M13 22.75H9C3.57 22.75 1.25 20.43 1.25 15V9C1.25 3.57 3.57 1.25 9 1.25H15C20.43 1.25 22.75 3.57 22.75 9V13C22.75 13.41 22.41 13.75 22 13.75C21.59 13.75 21.25 13.41 21.25 13V9C21.25 4.39 19.61 2.75 15 2.75H9C4.39 2.75 2.75 4.39 2.75 9V15C2.75 19.61 4.39 21.25 9 21.25H13C13.41 21.25 13.75 21.59 13.75 22C13.75 22.41 13.41 22.75 13 22.75Z" />
-    <path d="M7.33009 15.24C7.17009 15.24 7.0101 15.19 6.8701 15.08C6.5401 14.83 6.48012 14.36 6.73012 14.03L9.11009 10.94C9.40009 10.57 9.81011 10.33 10.2801 10.27C10.7501 10.21 11.2101 10.34 11.5801 10.63L13.4101 12.07C13.4801 12.13 13.5501 12.12 13.6001 12.12C13.6401 12.12 13.7101 12.1 13.7701 12.02L16.0801 9.04C16.3301 8.71 16.8001 8.65001 17.1301 8.91001C17.4601 9.16001 17.5201 9.63001 17.2601 9.96001L14.9501 12.94C14.6601 13.31 14.2501 13.55 13.7801 13.6C13.3201 13.66 12.8501 13.53 12.4901 13.24L10.6601 11.8C10.5901 11.74 10.5101 11.74 10.4701 11.75C10.4301 11.75 10.3601 11.77 10.3001 11.85L7.92012 14.94C7.78012 15.14 7.56009 15.24 7.33009 15.24Z" />
-    <path d="M20.26 22.7502C19.91 22.7502 19.46 22.6402 18.93 22.3202L18.68 22.1702C18.61 22.1302 18.3999 22.1302 18.3299 22.1702L18.0799 22.3202C16.9299 23.0102 16.2 22.7202 15.88 22.4802C15.55 22.2402 15.04 21.6402 15.34 20.3202L15.39 20.1102C15.41 20.0302 15.3499 19.8402 15.2999 19.7802L14.95 19.4302C14.36 18.8302 14.1299 18.1302 14.3299 17.5002C14.5299 16.8802 15.12 16.4402 15.95 16.3002L16.3299 16.2402C16.3999 16.2202 16.5399 16.1202 16.5799 16.0502L16.8599 15.4802C17.2499 14.6902 17.85 14.2402 18.51 14.2402C19.17 14.2402 19.77 14.6902 20.16 15.4802L20.44 16.0402C20.48 16.1102 20.62 16.2102 20.69 16.2302L21.07 16.2902C21.9 16.4302 22.49 16.8702 22.69 17.4902C22.89 18.1102 22.67 18.8102 22.07 19.4202L21.72 19.7702C21.67 19.8302 21.61 20.0202 21.63 20.1002L21.68 20.3102C21.98 21.6302 21.47 22.2302 21.14 22.4702C20.96 22.6102 20.67 22.7502 20.26 22.7502ZM18.49 15.7502C18.48 15.7602 18.34 15.8602 18.2 16.1502L17.92 16.7202C17.68 17.2102 17.1099 17.6302 16.5799 17.7202L16.2 17.7802C15.88 17.8302 15.77 17.9402 15.76 17.9602C15.76 17.9802 15.79 18.1402 16.02 18.3702L16.37 18.7202C16.78 19.1402 16.9899 19.8602 16.8599 20.4302L16.81 20.6402C16.72 21.0302 16.76 21.2002 16.78 21.2602C16.81 21.2402 16.98 21.2202 17.31 21.0202L17.56 20.8702C18.11 20.5402 18.9 20.5402 19.45 20.8702L19.7 21.0202C20.11 21.2702 20.28 21.2402 20.29 21.2402C20.25 21.2402 20.3 21.0402 20.21 20.6402L20.16 20.4302C20.03 19.8502 20.24 19.1402 20.65 18.7202L21 18.3702C21.23 18.1402 21.26 17.9802 21.26 17.9502C21.25 17.9302 21.14 17.8302 20.82 17.7702L20.44 17.7102C19.9 17.6202 19.34 17.2002 19.1 16.7102L18.82 16.1502C18.66 15.8502 18.52 15.7602 18.49 15.7502Z" />
-  </svg>
-);
-
-const ConnectionIcon = ({ className }: { className?: string }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    className={className}
-  >
-    <path d="M13.6405 10.36C14.5505 11.27 14.5505 12.74 13.6405 13.65C12.7305 14.56 11.2605 14.56 10.3505 13.65C9.44047 12.74 9.44047 11.27 10.3505 10.36C11.2605 9.44999 12.7305 9.44999 13.6405 10.36Z" />
-    <path d="M21.3904 10.52C22.2104 11.34 22.2104 12.66 21.3904 13.48C20.5704 14.3 19.2504 14.3 18.4304 13.48C17.6104 12.66 17.6104 11.34 18.4304 10.52C19.2504 9.69997 20.5704 9.69997 21.3904 10.52Z" />
-    <g opacity="0.4">
-      <path d="M5.57012 10.52C6.39012 11.34 6.39012 12.66 5.57012 13.48C4.75012 14.3 3.43012 14.3 2.61012 13.48C1.79012 12.66 1.79012 11.34 2.61012 10.52C3.43012 9.69997 4.75012 9.69997 5.57012 10.52Z" />
-    </g>
-    <g opacity="0.4">
-      <path d="M17.4305 3.66999C18.2505 4.48999 18.2505 5.80999 17.4305 6.62999C16.6105 7.44999 15.2905 7.44999 14.4705 6.62999C13.6505 5.80999 13.6505 4.48999 14.4705 3.66999C15.2905 2.84999 16.6105 2.84999 17.4305 3.66999Z" />
-    </g>
-    <path d="M9.53008 17.37C10.3501 18.19 10.3501 19.51 9.53008 20.33C8.71008 21.15 7.39008 21.15 6.57008 20.33C5.75008 19.51 5.75008 18.19 6.57008 17.37C7.39008 16.55 8.71008 16.55 9.53008 17.37Z" />
-    <path d="M9.53008 3.66999C10.3501 4.48999 10.3501 5.80999 9.53008 6.62999C8.71008 7.44999 7.39008 7.44999 6.57008 6.62999C5.75008 5.80999 5.75008 4.48999 6.57008 3.66999C7.39008 2.84999 8.71008 2.84999 9.53008 3.66999Z" />
-    <g opacity="0.4">
-      <path d="M17.4305 17.37C18.2505 18.19 18.2505 19.51 17.4305 20.33C16.6105 21.15 15.2905 21.15 14.4705 20.33C13.6505 19.51 13.6505 18.19 14.4705 17.37C15.2905 16.55 16.6105 16.55 17.4305 17.37Z" />
-    </g>
-    <g opacity="0.4">
-      <path d="M9.09001 17.79C8.96001 17.79 8.83001 17.76 8.72001 17.69C8.36001 17.48 8.24001 17.02 8.45001 16.67L10.2 13.64C10.41 13.28 10.87 13.16 11.22 13.37C11.58 13.58 11.7 14.04 11.49 14.39L9.74001 17.42C9.60001 17.66 9.35001 17.8 9.09001 17.8V17.79Z" />
-    </g>
-    <g opacity="0.4">
-      <path d="M10.84 10.74C10.58 10.74 10.33 10.61 10.19 10.36L8.44001 7.33C8.23001 6.97 8.36001 6.51 8.71001 6.31C9.07001 6.1 9.53001 6.23 9.73001 6.58L11.48 9.61C11.69 9.97 11.56 10.43 11.21 10.63C11.09 10.7 10.96 10.73 10.84 10.73V10.74Z" />
-    </g>
-    <g opacity="0.4">
-      <path d="M17.8103 12.75H14.3203C13.9103 12.75 13.5703 12.41 13.5703 12C13.5703 11.59 13.9103 11.25 14.3203 11.25H17.8103C18.2203 11.25 18.5603 11.59 18.5603 12C18.5603 12.41 18.2203 12.75 17.8103 12.75Z" />
-    </g>
-  </svg>
-);
-
-// Per-env public search relay; no in-source fallback (see runtimeEnv).
-const RELAY_URL = env.VITE_WOT_SEARCH_RELAY;
-
-const QUICK_START_SNIPPET = `["REQ", "search-1", {
-  "kinds": [0],
-  "search": "jack"
-}]`;
-
-const PERSONALIZED_SNIPPET = `["REQ", "search-1", {
-  "kinds": [0],
-  "limit": 20,
-  "search": "jack observer:<your-pubkey> sort:followers:desc filter:rank:gte:2"
-}]`;
-
-const EXTENSIONS: { name: string; format: string; description: string }[] = [
-  {
-    name: "observer",
-    format: "observer:<hex-pubkey>",
-    description:
-      "The user's pubkey. Results are processed by that user's community. Omit to use the relay's default point of view.",
-  },
-  {
-    name: "sort",
-    format: "sort:<metric>:<asc|desc>",
-    description: "Sort by a trust metric. Common metrics: followers, rank",
-  },
-  {
-    name: "filter",
-    format: "filter:<metric>:<op>:<value>",
-    description: "Filter by a trust metric threshold. Operators: gte, lte, gt, lt, eq",
-  },
-];
-
-const GITHUB_REPOS: { label: string; description: string; href: string }[] = [
-  {
-    label: "NosFabrica",
-    description: "Brainstorm website, relay & personalization service",
-    href: "https://github.com/NosFabrica",
-  },
-];
-
-function SectionCard({
-  icon,
-  title,
-  children,
-  testId,
-}: {
+// The developer landing/index: an editorial hero + one clickable card per way to
+// bring Brainstorm's web-of-trust scores into a nostr client. Each card links to
+// its own detail page. (Relay Tools is intentionally omitted until confirmed.)
+const METHODS: {
+  href: string;
   icon: React.ReactNode;
   title: string;
-  children: React.ReactNode;
+  description: string;
   testId: string;
-}) {
-  return (
-    <section
-      className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden"
-      data-testid={testId}
-    >
-      <div className="p-6 sm:p-8 space-y-4">
-        <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-xl bg-[#7c86ff]/10 border border-[#7c86ff]/20 flex items-center justify-center shrink-0">
-            {icon}
-          </div>
-          <h2
-            className="text-xl font-bold text-slate-900 tracking-tight"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            {title}
-          </h2>
-        </div>
-        {children}
-      </div>
-    </section>
-  );
-}
+}[] = [
+  {
+    href: "/developers/nip-50",
+    icon: <ConnectionIcon className="h-5 w-5 text-[#333286]" />,
+    title: "NIP-50 relay search",
+    description:
+      "Full-text profile search over the nostr relay protocol (WebSocket), with web-of-trust sort/filter extensions.",
+    testId: "card-method-nip50",
+  },
+  {
+    href: "/developers/open-ranking",
+    icon: <FavoriteChartIcon className="h-5 w-5 text-[#333286]" />,
+    title: "Open Ranking (ORE)",
+    description:
+      "An HTTP/JSON interface to the web of trust — capability discovery, per-pubkey stats, and ranked profile search.",
+    testId: "card-method-open-ranking",
+  },
+  {
+    href: "/developers/trusted-assertions",
+    icon: <BadgeCheck className="h-5 w-5 text-[#333286]" />,
+    title: "Trusted Assertions",
+    description:
+      "Web-of-trust scores published as ordinary nostr events (NIP-85), so any client can fetch and verify them.",
+    testId: "card-method-trusted-assertions",
+  },
+];
 
 export default function DevelopersPage() {
-  const [, navigate] = useLocation();
-  const { toast } = useToast();
-
-  const copyRelay = async () => {
-    try {
-      await copyToClipboard(RELAY_URL);
-      toast({ title: "Copied!", description: "Relay URL copied to clipboard" });
-    } catch {
-      /* clipboard unavailable */
-    }
-  };
-
   return (
     <InfoPageLayout testId="page-developers">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
@@ -169,168 +57,59 @@ export default function DevelopersPage() {
               style={{ fontFamily: "var(--font-display)" }}
               data-testid="text-dev-title"
             >
-              Add Brainstorm Search to <span className="text-[#333286]">your nostr client</span>.
+              Integrate the web of trust into <span className="text-[#333286]">your nostr client</span>.
             </h1>
             <p className="mt-5 text-lg text-slate-600 leading-relaxed max-w-2xl" data-testid="text-dev-subtitle">
-              This relay supports NIP-50 full-text profile search. Any nostr client can query it over a
-              standard WebSocket connection.
+              Three ways to bring this instance's Brainstorm scores into your app. Pick a method.
             </p>
           </header>
 
-          {/* Relay URL */}
-          <SectionCard
-            icon={<ConnectionIcon className="h-5 w-5 text-[#333286]" />}
-            title="Relay URL"
-            testId="card-dev-relay"
-          >
-            <div className="flex items-center gap-2 rounded-xl bg-slate-50 border border-slate-200 px-4 py-3">
-              <code className="flex-1 font-mono text-[14px] text-indigo-700 break-all" data-testid="text-relay-url">
-                {RELAY_URL}
-              </code>
-              <button
-                type="button"
-                onClick={copyRelay}
-                className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[12px] font-medium text-slate-600 bg-white hover:bg-slate-100 border border-slate-200 shadow-sm transition-colors shrink-0"
-                data-testid="button-copy-relay"
+          {/* Method cards */}
+          <div className="space-y-4" data-testid="section-dev-methods">
+            {METHODS.map((m) => (
+              <Link
+                key={m.href}
+                href={m.href}
+                className="group flex items-center gap-5 rounded-2xl border border-slate-200 bg-white hover:border-[#7c86ff]/40 hover:shadow-sm transition-all p-6"
+                data-testid={m.testId}
               >
-                <Copy className="h-3.5 w-3.5" />
-                Copy
-              </button>
-            </div>
-          </SectionCard>
+                <div className="h-12 w-12 rounded-xl bg-[#7c86ff]/10 border border-[#7c86ff]/20 flex items-center justify-center shrink-0">
+                  {m.icon}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-lg font-bold text-slate-900 tracking-tight" style={{ fontFamily: "var(--font-display)" }}>
+                    {m.title}
+                  </p>
+                  <p className="mt-1 text-[15px] text-slate-600 leading-relaxed">{m.description}</p>
+                </div>
+                <ArrowRight className="h-5 w-5 text-[#7c86ff] shrink-0 group-hover:translate-x-1 transition-transform" />
+              </Link>
+            ))}
+          </div>
 
-          {/* Quick Start */}
-          <SectionCard
-            icon={<Terminal className="h-5 w-5 text-[#333286]" />}
-            title="Quick Start"
-            testId="card-dev-quickstart"
-          >
-            <p className="text-[15px] text-slate-600 leading-relaxed">
-              Connect via WebSocket and send a standard NIP-50 search REQ:
-            </p>
-            <CodeBlock code={QUICK_START_SNIPPET} testId="quickstart" />
-            <p className="text-[15px] text-slate-600 leading-relaxed">
-              This returns kind 0 profile events filtered and sorted by the community of the relay's default
-              nostr profile. All standard nostr traffic (non-search REQs, EVENT publishing) passes through to
-              the underlying strfry relay transparently.
-            </p>
-          </SectionCard>
+          {/* Quick "which one?" chooser — organized by goal, not by method, so it
+              stays useful alongside the cards above (a method can serve more than
+              one goal; Open Ranking appears under both). */}
+          <div className="rounded-xl border border-[#7c86ff]/20 bg-[#7c86ff]/[0.04] px-5 py-4" data-testid="dev-chooser">
+            <p className="text-sm font-semibold text-slate-700">Which one do you need?</p>
+            <ul className="mt-2 space-y-1.5 text-[14px] text-slate-600">
+              <li>
+                <span className="text-slate-500">Looking up pubkeys (search / discovery)</span> →{" "}
+                <Link href="/developers/nip-50" className="font-medium text-[#333286] hover:underline">NIP-50</Link>{" "}
+                <span className="text-slate-400">(WebSocket)</span> or{" "}
+                <Link href="/developers/open-ranking" className="font-medium text-[#333286] hover:underline">Open Ranking</Link>{" "}
+                <span className="text-slate-400">(HTTP)</span>
+              </li>
+              <li>
+                <span className="text-slate-500">Have a pubkey, want its scores</span> →{" "}
+                <Link href="/developers/trusted-assertions" className="font-medium text-[#333286] hover:underline">Trusted Assertions</Link>{" "}
+                or{" "}
+                <Link href="/developers/open-ranking" className="font-medium text-[#333286] hover:underline">Open Ranking</Link>
+              </li>
+            </ul>
+          </div>
 
-          {/* Personalized Results */}
-          <SectionCard
-            icon={<BrainLogo size={20} className="text-[#333286]" />}
-            title="Personalized Results with WoT Extensions"
-            testId="card-dev-personalized"
-          >
-            <p className="text-[15px] text-slate-600 leading-relaxed">
-              Add custom extensions to the search string to get results personalized to a specific user
-              (filtered and sorted by that user's community):
-            </p>
-            <CodeBlock code={PERSONALIZED_SNIPPET} testId="personalized" />
-
-            <div className="overflow-x-auto rounded-xl border border-slate-200">
-              <table className="w-full text-left border-collapse" data-testid="table-extensions">
-                <thead>
-                  <tr className="bg-slate-50">
-                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">
-                      Extension
-                    </th>
-                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">
-                      Format
-                    </th>
-                    <th className="px-4 py-2.5 text-[11px] font-bold uppercase tracking-wide text-[#333286]">
-                      Description
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {EXTENSIONS.map((ext) => (
-                    <tr
-                      key={ext.name}
-                      className="border-t border-slate-100 align-top"
-                      data-testid={`row-extension-${ext.name}`}
-                    >
-                      <td className="px-4 py-3">
-                        <code className="font-mono text-[13px] font-semibold text-indigo-600">{ext.name}</code>
-                      </td>
-                      <td className="px-4 py-3">
-                        <code className="font-mono text-[13px] text-slate-700 whitespace-nowrap">
-                          {ext.format}
-                        </code>
-                      </td>
-                      <td className="px-4 py-3 text-[14px] text-slate-600 leading-relaxed min-w-[200px]">
-                        {ext.description}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </SectionCard>
-
-          {/* Automatic Score Provisioning */}
-          <SectionCard
-            icon={<FavoriteChartIcon className="h-5 w-5 text-[#333286]" />}
-            title="Automatic Score Provisioning"
-            testId="card-dev-provisioning"
-          >
-            <p className="text-[15px] text-slate-600 leading-relaxed">
-              The first time you search with a new observer, the relay automatically loads that user's
-              Brainstorm data in the background if it is available. In the meantime, the search returns
-              results using the relay's default perspective. Once loaded, subsequent searches will return
-              results that are fully personalized.
-            </p>
-          </SectionCard>
-
-          {/* Open-source */}
-          <SectionCard
-            icon={<Github className="h-5 w-5 text-[#333286]" />}
-            title="Open-source"
-            testId="card-dev-opensource"
-          >
-            <p className="text-[15px] text-slate-600 leading-relaxed">
-              Brainstorm is built in the open. Explore the code, file issues, or contribute:
-            </p>
-            <div className="grid sm:grid-cols-2 gap-3">
-              {GITHUB_REPOS.map((repo) => (
-                <a
-                  key={repo.label}
-                  href={repo.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center justify-between gap-3 rounded-xl bg-white border border-slate-200 hover:border-[#7c86ff]/40 hover:shadow-sm transition-all px-4 py-3"
-                  data-testid={`link-github-${repo.label.toLowerCase().replace(/\s+/g, "-")}`}
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="h-9 w-9 rounded-lg bg-[#7c86ff]/10 border border-[#7c86ff]/20 flex items-center justify-center shrink-0">
-                      <Github className="h-4.5 w-4.5 text-[#333286]" />
-                    </div>
-                    <div>
-                      <p className="text-sm font-semibold text-slate-900">{repo.label}</p>
-                      <p className="text-xs text-slate-500">{repo.description}</p>
-                    </div>
-                  </div>
-                  <ExternalLink className="h-4 w-4 text-[#7c86ff] shrink-0 group-hover:translate-x-0.5 transition-transform" />
-                </a>
-              ))}
-            </div>
-          </SectionCard>
-
-          {/* Cross-link */}
-          <button
-            onClick={() => navigate("/how-search-works")}
-            className="group w-full text-left rounded-2xl border border-slate-200 bg-white hover:border-[#7c86ff]/40 hover:shadow-sm transition-all p-6 flex items-center justify-between gap-4"
-            data-testid="link-to-how-search-works"
-          >
-            <div>
-              <p className="text-[11px] font-mono font-semibold tracking-[0.2em] text-[#7c86ff] uppercase mb-1.5">Keep reading</p>
-              <p className="text-base font-semibold text-slate-900">
-                Want the bigger picture on how trust ranking works?
-              </p>
-              <p className="text-sm text-slate-500 mt-0.5">See How Search Works</p>
-            </div>
-            <ArrowRight className="h-5 w-5 text-[#7c86ff] shrink-0 group-hover:translate-x-1 transition-transform" />
-          </button>
+          <OpenSourceSection />
         </div>
       </div>
     </InfoPageLayout>

--- a/client/src/pages/EventPage.tsx
+++ b/client/src/pages/EventPage.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { nip19 } from "nostr-tools";
 import { ArrowLeft, BadgeCheck, Smartphone, Loader2, MessageSquare, ArrowRight, Share2, Check, X } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { tierForScore } from "@/components/share/TrustScoreBadge";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 import { fetchEventsByIds, fetchAddressableEvents, fetchProfile, fetchProfileMap, getCurrentUser, hasPersistentKey, PROFILE_RELAYS } from "@/services/nostr";
 import { apiClient, hasSessionToken } from "@/services/api";
 import { collectRefs, addrCoord, type MinimalEvent } from "@/lib/noteRefs";
@@ -198,7 +198,6 @@ export default function EventPage() {
   const authorName = profile.display_name || profile.name || (authorPk ? npubFromPubkey(authorPk).slice(0, 12) + "…" : "Someone");
   const authorNpub = authorPk ? (() => { try { return npubFromPubkey(authorPk); } catch { return ""; } })() : "";
   const score01 = typeof trustQuery.data === "number" ? trustQuery.data : null;
-  const tier = score01 != null ? tierForScore(score01) : null;
   const firstName = authorName.split(" ")[0];
 
   const snippet = (note?.content || "").replace(/\s+/g, " ").trim().slice(0, 160);
@@ -322,15 +321,8 @@ export default function EventPage() {
                   <span className="text-xs text-slate-400">{ago(note.created_at)}</span>
                 </div>
               </Link>
-              {tier && (
-                <span
-                  className="ml-auto shrink-0 inline-flex items-center gap-1.5 rounded-full border pl-1.5 pr-2.5 py-1 text-[11px] font-bold uppercase tracking-wide"
-                  style={{ color: tier.color, backgroundColor: `${tier.color}14`, borderColor: `${tier.color}55` }}
-                  title="Author's network Web-of-Trust score"
-                >
-                  <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tier.color }} />
-                  {tier.name} · {Math.round((score01 ?? 0) * 100)}
-                </span>
+              {typeof score01 === "number" && Number.isFinite(score01) && (
+                <VerificationCoin score01={score01} pov="global" size={24} className="ml-auto" />
               )}
             </div>
 

--- a/client/src/pages/SharePage.tsx
+++ b/client/src/pages/SharePage.tsx
@@ -19,13 +19,7 @@ import {
   Copy,
   Check,
   SlidersHorizontal,
-  Users,
-  UserCheck,
   UserPlus,
-  VolumeX,
-  Flag,
-  ExternalLink,
-  type LucideIcon,
 } from "lucide-react";
 import { decodeShareId, npubFromPubkey, nostrUriFor, eventPath } from "@/lib/shareId";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -55,13 +49,14 @@ import { ProfileCustomizer } from "@/components/share/ProfileCustomizer";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { DegreeChip } from "@/components/DegreeChip";
 import { useRelationshipBadges } from "@/hooks/useRelationshipBadges";
-import { ProfileActions } from "@/components/share/ProfileActions";
-import { useScorePov } from "@/components/score/TrustScorePov";
+import { ProfileActions, OwnerActions } from "@/components/share/ProfileActions";
+import { Stat, StatLensToggle, type StatLens } from "@/components/share/StatToggle";
+import { useScorePov, TrustScoreModal } from "@/components/score/TrustScorePov";
+import { VerificationCoin } from "@/components/score/VerificationCoin";
 import { extractImageUrls, extractVideoUrls, extractVideoPoster } from "@/lib/noteContent";
 import { tierForScore } from "@/components/share/TrustScoreBadge";
 import { isFlaggedByReporters } from "@/lib/trustFlags";
 import { FlashIcon } from "@/components/FlashIcon";
-import { WotStrengthCard } from "@/components/WotStrengthCard";
 import { ZapModal } from "@/components/ZapModal";
 import { ContentTeaserBlock } from "@/components/share/ContentTeaserBlock";
 import { ShareProfileModal } from "@/components/ShareProfileModal";
@@ -95,6 +90,10 @@ export default function SharePage() {
   const [shareOpen, setShareOpen] = useState(false);
   const [zapOpen, setZapOpen] = useState(false);
   const [npubCopied, setNpubCopied] = useState(false);
+  const [scoreModalOpen, setScoreModalOpen] = useState(false);
+  // One shared lens for the whole stats block: verified (trust-filtered) vs all
+  // (raw). Defaults to verified — Brainstorm's bot-free view is the headline.
+  const [statLens, setStatLens] = useState<StatLens>("verified");
 
   const profileQuery = useQuery({
     queryKey: ["share-profile", pubkey],
@@ -425,17 +424,24 @@ export default function SharePage() {
   // total (per CEO: total following is more meaningful than verified following).
   const stats = statsQuery.data?.data as
     | {
-        followed_by?: { verified?: number };
-        following?: { total?: number };
-        muted_by?: { verified?: number };
-        reported_by?: { verified?: number };
+        followed_by?: { verified?: number; total?: number };
+        following?: { total?: number; verified?: number };
+        muted_by?: { verified?: number; total?: number };
+        reported_by?: { verified?: number; total?: number };
       }
     | undefined;
   const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+  // Each stat carries BOTH the web-of-trust-filtered (`verified`) and raw
+  // (`total`, includes bots) count in one response — the StatToggle flips between
+  // them client-side. No extra request.
   const verifiedFollowers = num(stats?.followed_by?.verified);
+  const allFollowers = num(stats?.followed_by?.total);
   const followingTotal = num(stats?.following?.total);
+  const verifiedFollowing = num(stats?.following?.verified);
   const verifiedMuters = num(stats?.muted_by?.verified);
+  const allMuters = num(stats?.muted_by?.total);
   const verifiedReporters = num(stats?.reported_by?.verified);
+  const allReporters = num(stats?.reported_by?.total);
   // Flagged = reported by more than 5 verified accounts, +1 forgiven per 750
   // verified followers (house POV → same verdict for every viewer).
   const isFlagged = isFlaggedByReporters(verifiedReporters ?? 0, verifiedFollowers ?? 0);
@@ -734,67 +740,97 @@ export default function SharePage() {
   // differs from the primary after rounding.
   // Which POV leads follows the sitewide score-POV toggle (personalized vs
   // global) — the personalized number only leads when the viewer chose it.
-  const leadWithMine = loggedIn && score01 != null && scorePov === "personalized";
-  const cardPrimaryScore = leadWithMine ? score01 : primaryScore01;
-  const cardSecondaryScore = leadWithMine ? houseScore01 : loggedIn ? score01 : null;
-  // Logged-in relationship actions — rendered inside the WoT card (as its footer)
-  // so the primary Follow action sits with the trust context as one cohesive unit,
-  // instead of a floating pill below it.
-  const loggedInActions = loggedIn ? (
-    <div className="flex flex-col gap-2" data-testid="share-actions-block">
-      {rel.enabled && !isOwner && !rel.loading && (rel.followsYou || rel.isFollowing || rel.isMuted || rel.report) && (() => {
-        const parts: { key: string; text: string; Icon: LucideIcon; className?: string }[] = [];
-        if (rel.isFollowing && rel.followsYou) parts.push({ key: "mutual", text: "You follow each other", Icon: Users });
-        else if (rel.isFollowing) parts.push({ key: "following", text: "You follow them", Icon: UserCheck });
-        else if (rel.followsYou) parts.push({ key: "follows-you", text: "They follow you", Icon: UserPlus });
-        if (rel.isMuted) parts.push({ key: "muted", text: "You've muted them", Icon: VolumeX });
-        if (rel.report) parts.push({ key: "reported", text: "You reported this", Icon: Flag, className: "text-amber-600" });
-        return (
-          <p className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[11px] text-slate-400" data-testid="share-relationship-summary">
-            {parts.map((p, i) => (
-              <span key={p.key} className="inline-flex items-center">
-                {i > 0 && <span className="text-slate-300 mr-2.5">·</span>}
-                <span className={`inline-flex items-center gap-1 ${p.className ?? ""}`}>
-                  <p.Icon className="h-3 w-3" /> {p.text}
-                </span>
-              </span>
-            ))}
-          </p>
-        );
-      })()}
-      {isOwner ? (
-        /* Owner: no self-actions. A quiet link to the analytics view. */
-        <Link
-          href={`/profile/${npub}`}
-          className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-400 hover:text-slate-600 transition-colors"
-          data-testid="share-advanced-view-owner"
+  // The Verification Score coin reflects the ACTIVE point of view (the sitewide
+  // toggle): personalized → the viewer's own score; global → the network (house)
+  // score. Logged-out visitors are always global. Null → unrated coin ("—").
+  const coinScore01 = scorePov === "personalized" ? score01 : houseScore01 ?? score01;
+  // Contact as compact clickable icons — website, lightning address, external
+  // identities. Lives top-right with the actions (and has a mobile fallback row),
+  // never as verbose text at the bottom.
+  const hasContactIcons = !!(profile.website || profile.lud16 || (identities.length > 0 && !isHidden("identities")));
+  const contactIcons = hasContactIcons ? (
+    <>
+      {profile.website && (
+        <a
+          href={normalizeUrl(profile.website)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-[#6366f1]"
+          title={profile.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}
+          aria-label="Website"
+          data-testid="share-website"
         >
-          <ExternalLink className="h-3.5 w-3.5" /> Advanced view
-        </Link>
-      ) : (
-        /* Non-owner: relationship actions. Keyed on the loaded relationship so it
-           re-seeds once useRelationshipBadges settles. */
-        <ProfileActions
-          key={`${rel.isFollowing}-${rel.isMuted}-${!!rel.report}`}
-          targetPubkey={pubkey}
-          npub={npub}
-          initialFollowing={rel.isFollowing}
-          initialMuted={rel.isMuted}
-          alreadyReported={!!rel.report}
-        />
+          <Globe className="h-4 w-4" />
+        </a>
       )}
-    </div>
+      {profile.lud16 && (
+        <button
+          type="button"
+          onClick={() => setZapOpen(true)}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-[#F7931A] transition-colors hover:bg-[#F7931A]/10 hover:text-[#e07f12]"
+          title={`Lightning — ${profile.lud16}`}
+          aria-label="Lightning address"
+          data-testid="share-lightning"
+        >
+          <FlashIcon className="h-4 w-4" />
+        </button>
+      )}
+      {identities.length > 0 && !isHidden("identities") && (
+        <span className="inline-flex items-center gap-2.5" data-testid="share-identities">
+          <ExternalIdentities identities={identities} />
+        </span>
+      )}
+    </>
   ) : null;
 
-  const wotCard = (
-    <WotStrengthCard
-      score01={cardPrimaryScore}
-      secondaryScore01={cardSecondaryScore}
-      primaryLabel={leadWithMine ? "For you" : "Everyone"}
-      secondaryLabel={leadWithMine ? "Everyone" : "For you"}
-      footer={loggedInActions}
+  // The action pieces, kept separate so we can place them differently per
+  // breakpoint: a "Follows you" chip, the contact icons, and the Follow/⋯ (or
+  // the owner's ⋯). On desktop all three sit together top-right with the avatar.
+  // On mobile the contact icons move up to the top-right slot under the banner
+  // (filling the dead space across from the avatar) while the Follow/⋯ actions
+  // drop to their own full-width row so the primary button can stretch.
+  const followsYouChip = loggedIn && rel.enabled && !isOwner && !rel.loading && rel.followsYou ? (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-500" data-testid="share-follows-you">
+      <UserPlus className="h-3 w-3" /> Follows you
+    </span>
+  ) : null;
+  const followButtons = loggedIn ? (isOwner ? (
+    <OwnerActions npub={npub} />
+  ) : (
+    <ProfileActions
+      key={`${rel.isFollowing}-${rel.isMuted}-${!!rel.report}`}
+      targetPubkey={pubkey}
+      npub={npub}
+      initialFollowing={rel.isFollowing}
+      initialMuted={rel.isMuted}
+      alreadyReported={!!rel.report}
     />
-  );
+  )) : null;
+  const hasFollowActions = !!followButtons;
+  const hasActions = loggedIn || hasContactIcons;
+
+  // Desktop: chip + icons + Follow/⋯ together, top-right with the avatar.
+  const topRightActions = hasActions ? (
+    <div className="hidden sm:flex items-center gap-2 shrink-0" data-testid="share-actions-topright">
+      {followsYouChip}
+      {contactIcons}
+      {followButtons}
+    </div>
+  ) : null;
+  // Mobile: just the contact icons, top-right across from the avatar.
+  const mobileTopIcons = hasContactIcons ? (
+    <div className="flex sm:hidden items-center gap-1 shrink-0" data-testid="share-icons-mobile">
+      {contactIcons}
+    </div>
+  ) : null;
+  // Mobile: the Follow/⋯ actions (+ follows-you chip) in their own row so the
+  // primary button can fill the width.
+  const mobileFollowRow = hasFollowActions ? (
+    <div className="mt-3 flex items-center gap-2 sm:hidden" data-testid="share-actions-mobile">
+      {followsYouChip}
+      {followButtons}
+    </div>
+  ) : null;
 
   return (
     <ShareShell onShare={() => setShareOpen(true)}>
@@ -815,12 +851,29 @@ export default function SharePage() {
           {/* key by pubkey so the Avatar remounts per profile — otherwise Radix
               keeps a stale "image loaded" status when navigating from a pictured
               profile to a pictureless one, hiding the fallback. */}
-          <Avatar key={pubkey} className="h-20 w-20 sm:h-24 sm:w-24 rounded-full border-4 border-white shadow-lg bg-white">
-            {profile.picture ? <AvatarImage src={profile.picture} alt={displayName} className="object-cover" /> : null}
-            <AvatarFallback className="overflow-hidden rounded-full">
-              <DefaultAvatarImg flagged={isFlagged} />
-            </AvatarFallback>
-          </Avatar>
+          <div className="flex items-end justify-between gap-3">
+            <div className="relative inline-block">
+              <Avatar key={pubkey} className="h-20 w-20 sm:h-24 sm:w-24 rounded-full border-4 border-white shadow-lg bg-white">
+                {profile.picture ? <AvatarImage src={profile.picture} alt={displayName} className="object-cover" /> : null}
+                <AvatarFallback className="overflow-hidden rounded-full">
+                  <DefaultAvatarImg flagged={isFlagged} />
+                </AvatarFallback>
+              </Avatar>
+              {/* Verification Score — the label-less coin, active-POV, bottom-right of
+                  the avatar. Tap opens the shared explainer/compare modal. */}
+              <VerificationCoin
+                score01={coinScore01}
+                pov={scorePov}
+                size={32}
+                onClick={() => setScoreModalOpen(true)}
+                className="absolute -bottom-1 -right-1"
+              />
+            </div>
+            {/* Desktop: chip + icons + Follow/⋯. Mobile: just the contact icons
+                here (top-right under the banner); Follow/⋯ render in a row below. */}
+            {topRightActions}
+            {mobileTopIcons}
+          </div>
 
           <div className="mt-2.5 md:flex md:gap-6 md:items-start">
             <div className="md:flex-1 min-w-0">
@@ -853,10 +906,15 @@ export default function SharePage() {
             </div>
           )}
 
-          {/* Web of Trust — mobile inline (desktop shows it in the right sidebar).
-              Logged-in actions live inside the card (its footer). */}
-          <div className="md:hidden mt-3">{wotCard}</div>
+          {/* Mobile: the Follow/⋯ actions in their own row under the identity so
+              the primary button can fill the width. Contact icons live top-right
+              (above), not here. */}
+          {mobileFollowRow}
 
+          {/* Tags — the team's WoT-ranked attribute chips (Verified human, Founder,
+              …) will render here, colored in the personalized view / greyscale in
+              global, with a "+N → see all". Deferred until tag data ships; for now
+              the owner-set role chips below stand in. */}
           {roleLabels.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-1.5" data-testid="share-roles">
               {roleLabels.map((label) => (
@@ -892,48 +950,81 @@ export default function SharePage() {
             </div>
           )}
 
-          {/* Stats — trust chip leads; positive signals, then a quieter risk line. */}
+          {/* Stats — one shared Verified/All lens for the whole block (tap the
+              toggle to reveal how many bots the web of trust filters out). Each
+              count links to its full list. */}
           <div className="mt-2.5 space-y-1.5" data-testid="share-stats">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-slate-500">
-              {followingTotal != null && (
-                <Link href={`/p/${rawId}/following`} className="hover:text-slate-700 transition-colors" data-testid="share-stat-following">
-                  <span className="font-semibold text-slate-700">{followingTotal.toLocaleString()}</span> Following
-                </Link>
-              )}
-              {verifiedFollowers != null && (
-                <Link href={`/p/${rawId}/followers`} className="hover:text-slate-700 transition-colors" data-testid="share-stat-followers" title="Verified followers in the web of trust">
-                  <span className="font-semibold text-slate-700">{verifiedFollowers.toLocaleString()}</span> Verified Followers
-                </Link>
-              )}
-              {/* Degree (LinkedIn-style 1st/2nd/3rd) — a "good" metric, so it sits
-                  on line 1. Signed-in + scored viewers only (needs my pubkey as the
-                  path origin); hidden on your own profile. */}
-              {loggedIn && currentUser?.pubkey && pubkey && currentUser.pubkey !== pubkey &&
-                localStorage.getItem("brainstorm_calc_completed") === "true" && (
-                  <DegreeChip fromPubkey={currentUser.pubkey} toPubkey={pubkey} rawId={rawId} />
+            <div className="space-y-1.5">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-slate-500">
+                {(followingTotal != null || verifiedFollowing != null) && (
+                  <Stat
+                    verified={verifiedFollowing}
+                    all={followingTotal}
+                    verifiedLabel="Verified Following"
+                    allLabel="Following"
+                    href={`/p/${rawId}/following`}
+                    lens={statLens}
+                    testId="share-stat-following"
+                  />
                 )}
-            </div>
-            {(verifiedMuters != null || verifiedReporters != null) && (
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-slate-400">
-                {verifiedMuters != null && (
-                  <Link href={`/p/${rawId}/muters`} className="hover:text-slate-600 transition-colors" data-testid="share-stat-muters" title="Verified accounts that have muted this profile">
-                    <span className="font-semibold text-slate-500">{verifiedMuters.toLocaleString()}</span> Verified Muters
-                  </Link>
+                {(verifiedFollowers != null || allFollowers != null) && (
+                  <Stat
+                    verified={verifiedFollowers}
+                    all={allFollowers}
+                    verifiedLabel="Verified Followers"
+                    allLabel="All Followers"
+                    href={`/p/${rawId}/followers`}
+                    lens={statLens}
+                    testId="share-stat-followers"
+                  />
                 )}
-                {verifiedReporters != null && (
-                  <Link href={`/p/${rawId}/reporters`} className={`transition-colors ${isFlagged ? "text-red-500 hover:text-red-600" : "hover:text-slate-600"}`} data-testid="share-stat-reporters" title="Verified accounts that have reported this profile">
-                    <span className={`font-semibold ${isFlagged ? "text-red-600" : "text-slate-500"}`}>{verifiedReporters.toLocaleString()}</span> Verified Reporters
-                  </Link>
-                )}
+                {/* Degree (LinkedIn-style 1st/2nd/3rd) — a "good" metric, so it sits
+                    on line 1. Signed-in + scored viewers only (needs my pubkey as the
+                    path origin); hidden on your own profile. */}
+                {loggedIn && currentUser?.pubkey && pubkey && currentUser.pubkey !== pubkey &&
+                  localStorage.getItem("brainstorm_calc_completed") === "true" && (
+                    <DegreeChip fromPubkey={currentUser.pubkey} toPubkey={pubkey} rawId={rawId} />
+                  )}
               </div>
+              {(verifiedMuters != null || allMuters != null || verifiedReporters != null || allReporters != null) && (
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-slate-400">
+                  {(verifiedMuters != null || allMuters != null) && (
+                    <Stat
+                      verified={verifiedMuters}
+                      all={allMuters}
+                      verifiedLabel="Verified Muters"
+                      allLabel="All Muters"
+                      href={`/p/${rawId}/muters`}
+                      lens={statLens}
+                      testId="share-stat-muters"
+                    />
+                  )}
+                  {(verifiedReporters != null || allReporters != null) && (
+                    <Stat
+                      verified={verifiedReporters}
+                      all={allReporters}
+                      verifiedLabel="Verified Reporters"
+                      allLabel="All Reporters"
+                      href={`/p/${rawId}/reporters`}
+                      lens={statLens}
+                      danger={isFlagged}
+                      testId="share-stat-reporters"
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+            {(verifiedFollowers != null || allFollowers != null) && (
+              <StatLensToggle value={statLens} onChange={setStatLens} />
             )}
           </div>
+          {/* end stats */}
 
-          {/* Social proof — most-trusted accounts who follow them (LinkedIn/FB style).
-              Mobile: inline here. Desktop: moved into the right rail under the WoT
-              card (a coherent "trust + who vouches for them" column). */}
+          {/* Social proof — most-trusted accounts who follow them (LinkedIn/FB style),
+              inline under the stats so it reads as a "who vouches for them" line
+              rather than floating in a side rail. */}
           {!isHidden("followedBy") && (
-            <div className="md:hidden">
+            <div className="mt-3">
               <FollowedByRow people={topFollowers} total={verifiedFollowers} href={`/p/${rawId}/followers`} />
             </div>
           )}
@@ -947,39 +1038,6 @@ export default function SharePage() {
             </p>
           )}
 
-          {/* Identity / contact — clean borderless inline row (LinkedIn-style).
-              Sharing lives in the header Share button + the Open-in-app section. */}
-          {(profile.website || profile.lud16 || (identities.length > 0 && !isHidden("identities"))) && (
-            <div className="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs">
-              {profile.website && (
-                <a
-                  href={normalizeUrl(profile.website)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 font-medium text-[#3730a3] hover:underline"
-                  data-testid="share-website"
-                >
-                  <Globe className="h-3.5 w-3.5" /> {profile.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}
-                </a>
-              )}
-              {profile.lud16 && (
-                <button
-                  type="button"
-                  onClick={() => setZapOpen(true)}
-                  className="inline-flex items-center gap-1 text-slate-500 hover:text-slate-800 transition-colors"
-                  title="Send a zap"
-                  data-testid="share-lightning"
-                >
-                  <FlashIcon className="h-3.5 w-3.5 text-yellow-400" /> {profile.lud16}
-                </button>
-              )}
-              {identities.length > 0 && !isHidden("identities") && (
-                <span className="inline-flex items-center gap-2.5" data-testid="share-identities">
-                  <ExternalIdentities identities={identities} />
-                </span>
-              )}
-            </div>
-          )}
 
           {/* Logged-out → the Join conversion panel (leads with the personal
               connection). Logged-in relationship actions live under the WoT card
@@ -1022,17 +1080,6 @@ export default function SharePage() {
               <Wifi className="h-3.5 w-3.5" /> Fetched live from relays — not yet indexed by Brainstorm.
             </p>
           )}
-            </div>
-            {/* Web of Trust — desktop sidebar (mobile shows it inline above).
-                Logged-in actions live inside the card (its footer); social proof
-                sits below it so the rail reads as one "trust signals" column. */}
-            <div className="hidden md:block md:w-64 md:shrink-0 mt-1">
-              {wotCard}
-              {!isHidden("followedBy") && topFollowers.length > 0 && (
-                <div className="mt-4 px-1">
-                  <FollowedByRow people={topFollowers} total={verifiedFollowers} href={`/p/${rawId}/followers`} stacked />
-                </div>
-              )}
             </div>
           </div>
         </div>
@@ -1252,6 +1299,11 @@ export default function SharePage() {
         </>
       )}
 
+      <TrustScoreModal
+        open={scoreModalOpen}
+        onOpenChange={setScoreModalOpen}
+        scores={{ personalized: score01, global: houseScore01 }}
+      />
       <ShareProfileModal open={shareOpen} onOpenChange={setShareOpen} npub={npub} displayName={displayName} picture={profile.picture} nip05={profile.nip05} canonicalUrl={canonicalUrl} score01={houseScore01} onOwnPage />
       {profile.lud16 && (
         <ZapModal open={zapOpen} onOpenChange={setZapOpen} recipientPubkey={pubkey} lud16={profile.lud16} displayName={displayName} picture={profile.picture} />

--- a/client/src/services/nostr.ts
+++ b/client/src/services/nostr.ts
@@ -2,6 +2,7 @@ import { nip19, finalizeEvent, getPublicKey, generateSecretKey, verifyEvent } fr
 import { encrypt as encryptSecretKeyNip49, decrypt as decryptSecretKeyNip49 } from "nostr-tools/nip49";
 import { RelayPool } from "applesauce-relay";
 import { env } from "@/lib/runtimeEnv";
+import { isVaultSupported, encryptSecret, decryptSecret } from "@/lib/skVault";
 
 const RAW_NIP85_RELAY_URL = env.VITE_NIP85_RELAY_URL;
 const NIP85_RELAY_URL = RAW_NIP85_RELAY_URL.trim().replace(/\/+$/, "");
@@ -64,10 +65,16 @@ declare global {
   }
 }
 
+// Ephemeral session copy for non-persistent logins (nsec paste without "remember
+// me", extension fallback) — plaintext, cleared when the tab closes.
 const SK_STORAGE_KEY = "brainstorm_sk_hex";
-// Persistent variant for self-custodial accounts created in-app, so they "stay
-// signed in" across sessions (extension/nsec flows keep using the session copy).
+// LEGACY plaintext persistent key. Read-only now (for one-time migration); we no
+// longer write it except in the rare vault-unsupported fallback. See SK_ENC_KEY.
 const SK_PERSIST_KEY = "brainstorm_sk_hex_persist";
+// Persistent account key, ENCRYPTED at rest (skVault device-key wrap). Holds a
+// versioned envelope, never the raw key. This is the default for created/restored
+// accounts that "stay signed in".
+const SK_ENC_KEY = "brainstorm_sk_enc";
 
 export type LoginErrorCode =
   | "NO_EXTENSION"
@@ -86,60 +93,202 @@ export class LoginError extends Error {
   }
 }
 
+// The decrypted persistent key lives ONLY here — a module-level variable, never
+// written back to any storage API. It's populated by `storeSecretKey` (fresh
+// login/create) or by `ensureUnlocked` (silent async decrypt on cold boot).
+let memSk: Uint8Array | null = null;
+let unlockPromise: Promise<void> | null = null;
+
+/**
+ * Synchronous read of the raw secret key for signing. Returns the in-memory copy
+ * if present; otherwise reconstructs it from the two PLAINTEXT sources that are
+ * safe to read synchronously — the ephemeral session key and the legacy plaintext
+ * persist key. The ENCRYPTED persistent key (`SK_ENC_KEY`) cannot be read here
+ * (decryption is async) — call `await ensureUnlocked()` first; every real sign
+ * path does, via `signEventLocally`.
+ */
 function getStoredSecretKey(): Uint8Array | null {
+  if (memSk) return memSk;
   try {
     const hex =
       sessionStorage.getItem(SK_STORAGE_KEY) || localStorage.getItem(SK_PERSIST_KEY);
-    if (!hex) return null;
-    return hexToBytes(hex);
+    if (hex) {
+      memSk = hexToBytes(hex);
+      return memSk;
+    }
   } catch {
-    return null;
+    /* ignore */
+  }
+  return null;
+}
+
+/**
+ * Populate `memSk` from persisted storage, decrypting the encrypted envelope if
+ * needed. Idempotent + memoized so concurrent callers share one in-flight decrypt.
+ * Silent (no password, no prompt). Also performs the one-time legacy→encrypted
+ * migration. Safe to call eagerly on boot and defensively before any local sign.
+ */
+export async function ensureUnlocked(): Promise<void> {
+  if (memSk) return;
+  if (unlockPromise) {
+    await unlockPromise;
+    return;
+  }
+  unlockPromise = doUnlock();
+  try {
+    await unlockPromise;
+  } finally {
+    unlockPromise = null;
   }
 }
 
-function storeSecretKey(sk: Uint8Array, opts?: { persistent?: boolean }): void {
+async function doUnlock(): Promise<void> {
+  if (memSk) return;
+
+  let sess: string | null = null;
+  let encEnvelope: string | null = null;
+  let legacy: string | null = null;
   try {
-    const hex = bytesToHex(sk);
-    if (opts?.persistent) {
-      // Created-in-app account: persist so the user stays signed in. Clear any
-      // stale session copy so the two stores never disagree.
-      localStorage.setItem(SK_PERSIST_KEY, hex);
-      sessionStorage.removeItem(SK_STORAGE_KEY);
-    } else {
-      sessionStorage.setItem(SK_STORAGE_KEY, hex);
-      localStorage.removeItem(SK_PERSIST_KEY);
+    sess = sessionStorage.getItem(SK_STORAGE_KEY);
+    encEnvelope = localStorage.getItem(SK_ENC_KEY);
+    legacy = localStorage.getItem(SK_PERSIST_KEY);
+  } catch {
+    return;
+  }
+
+  // Ephemeral session key (non-persistent login) — plaintext, never migrated.
+  if (sess) {
+    try {
+      memSk = hexToBytes(sess);
+    } catch {
+      /* ignore */
     }
-  } catch {}
+    return;
+  }
+
+  // Encrypted persistent key → decrypt with the device key, bound to this
+  // account's pubkey (AAD). A foreign/corrupt envelope throws → treated as "no
+  // key" (the user re-authenticates).
+  if (encEnvelope) {
+    const pubkey = getCurrentUser()?.pubkey;
+    if (pubkey && isVaultSupported()) {
+      try {
+        memSk = await decryptSecret(encEnvelope, pubkey);
+      } catch {
+        memSk = null;
+      }
+    }
+    return;
+  }
+
+  // Legacy plaintext persist → migrate in place: hold in memory, re-encrypt, and
+  // delete the plaintext. One-time, transparent, no user action.
+  if (legacy) {
+    try {
+      memSk = hexToBytes(legacy);
+    } catch {
+      return;
+    }
+    if (isVaultSupported()) {
+      try {
+        const envelope = await encryptSecret(memSk, getPublicKey(memSk));
+        localStorage.setItem(SK_ENC_KEY, envelope);
+        localStorage.removeItem(SK_PERSIST_KEY);
+      } catch {
+        /* leave the plaintext key as-is (vault-unsupported fallback) */
+      }
+    }
+  }
+}
+
+/**
+ * Persist (or session-scope) a freshly-obtained secret key and hold it in memory.
+ * Persistent keys are ENCRYPTED at rest via the device-key wrap; only if the
+ * vault is unavailable do we fall back to plaintext localStorage (parity with the
+ * old behavior — never orphan a brand-new account). Non-persistent keys stay in
+ * plaintext sessionStorage (ephemeral, cleared on tab close).
+ */
+async function storeSecretKey(sk: Uint8Array, opts?: { persistent?: boolean }): Promise<void> {
+  memSk = sk;
+  try {
+    if (opts?.persistent) {
+      sessionStorage.removeItem(SK_STORAGE_KEY);
+      if (isVaultSupported()) {
+        try {
+          const envelope = await encryptSecret(sk, getPublicKey(sk));
+          localStorage.setItem(SK_ENC_KEY, envelope);
+          localStorage.removeItem(SK_PERSIST_KEY);
+          return;
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[skVault] at-rest encryption failed — falling back to plaintext persist",
+            err,
+          );
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn("[skVault] at-rest encryption unavailable — falling back to plaintext persist");
+      }
+      // Fallback: plaintext persist (no worse than the prior behavior).
+      localStorage.setItem(SK_PERSIST_KEY, bytesToHex(sk));
+      localStorage.removeItem(SK_ENC_KEY);
+    } else {
+      sessionStorage.setItem(SK_STORAGE_KEY, bytesToHex(sk));
+      localStorage.removeItem(SK_PERSIST_KEY);
+      localStorage.removeItem(SK_ENC_KEY);
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 function clearSecretKey(): void {
+  memSk = null;
+  unlockPromise = null;
   try {
     sessionStorage.removeItem(SK_STORAGE_KEY);
     localStorage.removeItem(SK_PERSIST_KEY);
+    localStorage.removeItem(SK_ENC_KEY);
   } catch {}
 }
 
+/** True when a secret key is held or persisted in any form (memory / session /
+ * encrypted / legacy plaintext). A presence check — does NOT decrypt. */
+function hasAnyStoredKey(): boolean {
+  if (memSk) return true;
+  try {
+    return !!(
+      sessionStorage.getItem(SK_STORAGE_KEY) ||
+      localStorage.getItem(SK_ENC_KEY) ||
+      localStorage.getItem(SK_PERSIST_KEY)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function hasLocalSecretKey(): boolean {
-  return getStoredSecretKey() !== null;
+  return hasAnyStoredKey();
 }
 
 /** True when an in-app–created account's key is persisted locally ("stay signed in"). */
 export function hasPersistentKey(): boolean {
   try {
-    return !!localStorage.getItem(SK_PERSIST_KEY);
+    return !!(localStorage.getItem(SK_ENC_KEY) || localStorage.getItem(SK_PERSIST_KEY));
   } catch {
     return false;
   }
 }
 
 /**
- * True when we hold the raw secret key in this session (created/restored account
- * in localStorage, OR an nsec pasted into sessionStorage) — i.e. when we can back
+ * True when we hold the raw secret key for this account (created/restored account
+ * persisted locally, OR an nsec pasted into the session) — i.e. when we can back
  * it up or reveal it. False for extension logins, where the key never leaves the
- * signer.
+ * signer. Presence check only; the actual bytes come via `ensureUnlocked`.
  */
 export function hasStoredSecretKey(): boolean {
-  return !!getStoredSecretKey();
+  return hasAnyStoredKey();
 }
 
 function signWithStoredKey(event: Record<string, unknown>): Record<string, unknown> {
@@ -164,12 +313,14 @@ export async function signEventLocally(
       throw new Error("Extension returned an unsigned event");
     } catch (err) {
       if (hasLocalSecretKey()) {
+        await ensureUnlocked();
         return signWithStoredKey(event);
       }
       throw err;
     }
   }
   if (hasLocalSecretKey()) {
+    await ensureUnlocked();
     return signWithStoredKey(event);
   }
   throw new Error("No signer available. Please sign in again.");
@@ -1255,7 +1406,7 @@ async function authenticateWithSecretKey(sk: Uint8Array, opts?: { persistent?: b
 
   const signedEvent = finalizeEvent(eventTemplate, sk) as unknown as Record<string, unknown>;
 
-  storeSecretKey(sk, opts);
+  await storeSecretKey(sk, opts);
   try {
     const user = await completeLogin(pubkey, signedEvent);
     // The user supplied their own nsec → they demonstrably hold the key, so the
@@ -1599,7 +1750,7 @@ export async function createAccount(
   };
   const signedEvent = finalizeEvent(eventTemplate, sk) as unknown as Record<string, unknown>;
 
-  storeSecretKey(sk, { persistent: true });
+  await storeSecretKey(sk, { persistent: true });
   let user: NostrUser;
   try {
     user = await completeLogin(pubkey, signedEvent);


### PR DESCRIPTION
Deployed to **staging** (`brainstorm-staging.nosfabrica.com`) for review — the UI image tag on staging now tracks this branch.

## What's in here

### Verification Score coin + `/p` hero refinement (`64e3b6f`)
- Trust Score badge → a label-less **Verification Score coin**, propagated across surfaces: profile hero, connection lists, note cards, Event/Article author lines.
- POV-aware: saturated for the personalized view, grey for the global/house view; tier conveyed by hue + number.
- `/p` hero restructure: single-column identity, actions top-right, contact icons (globe + BTC-orange lightning) consolidated top-right (moving to the under-banner slot on mobile), single quiet Verified/All stat lens, inline "Followed by" with k/M abbreviation, owner ⋯ menu, coin sized to sit cleanly on the avatar.

### `/developers` redesign (`1c07408`)
- Editorial landing index + one detail page per integration method:
  - `/developers/nip-50` — relay full-text search (WebSocket) + WoT extensions
  - `/developers/open-ranking` — ORE HTTP/JSON interface (configurable base URL)
  - `/developers/trusted-assertions` — NIP-85 portable scores (kind 30382)
- Goal-based "which one?" chooser (look up pubkeys vs. fetch scores) + shared open-source card. Relay Tools intentionally omitted for now.

## Also on this branch (already reviewed / merged elsewhere)
- `e81f072` — encrypt persisted secret key at rest (WebCrypto device-key wrap)
- `5a85c0f` — admin activity `size=500` fix (#32, @en-nostr)

## Notes for review
- **Docs verbatim flag:** the Open Ranking + Trusted Assertions body text was copied from the team's mockup — the technical specifics (ORE endpoint behaviors, field meanings, ORE-01/02/05 refs) should be confirmed by whoever owns that API before it's considered authoritative.
- **Deferred:** the broader "trust score → Verification Score" copy sweep (explainer pages) — the coin, modal title, and WoT meter label are renamed; long-form explainer copy is not yet.
- Env to set on staging when ready: `VITE_WOT_SEARCH_RELAY`, and confirm the instance serves the ORE endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)