### PR TITLE
Fix the test suite on Node 26 (localStorage global shadows jsdom)

### DIFF
--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -8,6 +8,38 @@ window.__ENV__ = {
   VITE_NIP85_RELAY_URL: "wss://test.local",
 };
 
+/**
+ * Node 26 exposes a native experimental `localStorage` global that is undefined
+ * without `--localstorage-file`, and it shadows the one jsdom would provide. A
+ * bare `localStorage.setItem(...)` in a test therefore throws "Cannot read
+ * properties of undefined" in the `beforeEach` below, which takes out the
+ * entire suite before a single assertion runs — 76 tests across 12 files on
+ * `main` at the time of writing.
+ *
+ * Install a minimal in-memory Storage when nothing usable is present. A no-op
+ * on Node 20/22, where jsdom's own implementation is already there.
+ */
+if (typeof globalThis.localStorage?.setItem !== "function") {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  for (const target of [globalThis, window]) {
+    Object.defineProperty(target, "localStorage", {
+      value: storage,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
 beforeEach(() => {
   localStorage.clear();
 });


### PR DESCRIPTION
## The problem

`npx vitest run` on `main` fails **every test — 76 across 12 files** — before a single assertion runs.

Node 26 exposes a native experimental `localStorage` global that is `undefined` unless you pass `--localstorage-file`, and it shadows the implementation jsdom would otherwise provide. The `beforeEach` in `client/src/test/setup.ts` calls `localStorage.clear()`, which throws `Cannot read properties of undefined`, and every file dies in setup.

## The fix

Install a minimal in-memory `Storage` when nothing usable is present.

Guarded on `typeof globalThis.localStorage?.setItem !== "function"`, so it's a **no-op on Node 20/22** where jsdom's own implementation is already there — nobody on an older Node sees any change. Defined on both `globalThis` and `window`, because test code reaches for it either way.

## Verification

On Node 26.3.1, this branch vs `main`:

| | Result |
| --- | --- |
| `main` | 76 failed (12 files) |
| this branch | 76 passed (12 files) |

`npx tsc --noEmit` and `npm run check` clean.

## Why it's on its own

Split out of two in-flight feature branches that each had to carry it to verify themselves. It belongs on `main` independently: anyone cloning this repo and running the tests on a current Node today gets 76 red for reasons that have nothing to do with their work.

One file, +30 lines, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)