### PR TITLE
chore: publish security.txt, honest 404s, and per-deployment robots.txt

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,13 @@ Brainstorm runs across several hostnames. They share a small number of open-sour
 different release stages, which is why they resemble one another — **they are not clones of one
 another operated by different parties.** Every host below is operated by the same team.
 
+The canonical inventory of the estate — organizations, repositories, and hostnames — is
+[`ECOSYSTEM.md`](https://github.com/NosFabrica/protocols/blob/main/ECOSYSTEM.md) in
+[`NosFabrica/protocols`](https://github.com/NosFabrica/protocols), the repository that also houses
+the estate's shared protocol specifications. The tables below are the security-facing attestation of
+that inventory, scoped to this document's purpose; if they ever disagree with `ECOSYSTEM.md`, that
+file is right and this one has a bug.
+
 ### Product UI — [`NosFabrica/Brainstorm-UI`](https://github.com/NosFabrica/Brainstorm-UI) (this repository)
 
 | Host | Role |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,8 +63,10 @@ another operated by different parties.** Every host below is operated by the sam
 | `nip85.nosfabrica.com` | NIP-85 relay |
 | `nip85-staging.nosfabrica.com` | NIP-85 relay (staging) |
 
-**Any `*.brainstorm.world` or `*.nosfabrica.com` host not listed above is not operated by us.** If
-you find one impersonating this project, that itself is worth reporting through the link above.
+**The `brainstorm.world` and `nosfabrica.com` domains are both ours**, so any host under either of
+them is operated by us — the tables above are a current inventory, not an exhaustive claim. A site
+that resembles Brainstorm on any *other* domain is not affiliated with us; if you find one, that
+itself is worth reporting through the link above.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,87 @@
+# Security Policy
+
+Brainstorm is an open-source Web-of-Trust protocol and search engine built on nostr. This document is
+the target of the `Policy` field in the `security.txt` published by every Brainstorm deployment.
+
+## Reporting a vulnerability
+
+**Report privately through GitHub:**
+[Report a vulnerability](https://github.com/NosFabrica/Brainstorm-UI/security/advisories/new)
+
+Please do **not** open a public issue for a security report.
+
+Include whatever you have: the affected host or hosts, the version or commit if you know it,
+reproduction steps, and what impact you think it has. A partial report is more useful than none.
+
+### What to expect
+
+Brainstorm is a small team. We do not operate a paid bug bounty and cannot promise a fixed response
+window. We will acknowledge your report, tell you whether we consider it in scope, and let you know
+when a fix ships. If you would like credit in the release notes, say so.
+
+## Official deployments
+
+Brainstorm runs across several hostnames. They share a small number of open-source codebases at
+different release stages, which is why they resemble one another — **they are not clones of one
+another operated by different parties.** Every host below is operated by the same team.
+
+### Product UI — [`NosFabrica/Brainstorm-UI`](https://github.com/NosFabrica/Brainstorm-UI) (this repository)
+
+| Host | Role |
+|---|---|
+| `brainstorm.world` | Production |
+| `brainstorm.nosfabrica.com` | Production alias |
+| `brainstorm-staging.nosfabrica.com` | Staging |
+
+### R&D UI — [`nous-clawds4/tapestry`](https://github.com/nous-clawds4/tapestry)
+
+| Host | Role |
+|---|---|
+| `tapestry.brainstorm.world` | Reference deployment |
+| `staging.brainstorm.world` | Pre-production |
+| `tags.brainstorm.world` | Feature sandbox |
+| `communities.brainstorm.world` | Feature sandbox |
+| `magic-carpet.brainstorm.world` | Feature sandbox |
+| `curate.brainstorm.world` | Feature sandbox |
+
+### Backend APIs — [`NosFabrica/brainstorm_server`](https://github.com/NosFabrica/brainstorm_server)
+
+| Host | Role |
+|---|---|
+| `api.brainstorm.world` | Production API |
+| `search.brainstorm.world` | Search API |
+| `brainstormserver.nosfabrica.com` | Production API |
+| `brainstormserver-staging.nosfabrica.com` | Staging API |
+
+### nostr relays — [strfry](https://github.com/hoytech/strfry)
+
+| Host | Role |
+|---|---|
+| `scores.brainstorm.world` | Public relay |
+| `nip85.brainstorm.world` | NIP-85 Trusted Assertions |
+| `dcosl.brainstorm.world` | Decentralized Curation of Simple Lists |
+| `nip85.nosfabrica.com` | NIP-85 relay |
+| `nip85-staging.nosfabrica.com` | NIP-85 relay (staging) |
+
+**Any `*.brainstorm.world` or `*.nosfabrica.com` host not listed above is not operated by us.** If
+you find one impersonating this project, that itself is worth reporting through the link above.
+
+## Scope
+
+In scope: the codebases listed above and the deployments they serve.
+
+Out of scope: third-party nostr relays we do not operate, third-party clients that connect to our
+relays, and vulnerabilities in upstream dependencies (report those upstream, though we appreciate a
+heads-up).
+
+## A note on the trust model
+
+Brainstorm is built around a personalized Web of Trust. Publishing is permissionless by design:
+anyone may publish follows, mutes, reports, tags, and list elements, and the system does not gate
+publication. Trust filtering happens at read time, from a specific point of view.
+
+This means **"an untrusted party published a misleading assertion" is expected behavior, not a
+vulnerability.** Reports in that shape will be closed as working-as-intended. What *is* in scope is
+anything that breaks the per-POV filtering itself — for example, a way to make an assertion count for
+a point of view that never trusted its author, to forge or alter another user's signed events, or to
+read data a point of view should not be able to see.

--- a/client/public/.well-known/security.txt
+++ b/client/public/.well-known/security.txt
@@ -33,8 +33,10 @@
 #   nip85.nosfabrica.com
 #   nip85-staging.nosfabrica.com
 #
-# Any *.brainstorm.world or *.nosfabrica.com host not listed above is
-# not operated by us.
+# The brainstorm.world and nosfabrica.com domains are both ours, so any
+# host under either of them is operated by us. The list above is a
+# current inventory, not an exhaustive claim. A site that resembles
+# Brainstorm on any OTHER domain is not affiliated with us.
 # ---------------------------------------------------------------------
 
 Contact: https://github.com/NosFabrica/Brainstorm-UI/security/advisories/new

--- a/client/public/.well-known/security.txt
+++ b/client/public/.well-known/security.txt
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------
+# Brainstorm - official domain inventory
+#
+# Brainstorm is an open-source Web-of-Trust protocol and search engine
+# built on nostr. Every hostname below is operated by the same team.
+# They run a small number of shared open-source codebases at different
+# release stages, which is why they resemble one another. This file is
+# published identically on all of them as an ownership attestation.
+#
+# Product UI - github.com/NosFabrica/Brainstorm-UI
+#   brainstorm.world
+#   brainstorm.nosfabrica.com
+#   brainstorm-staging.nosfabrica.com
+#
+# R&D UI - github.com/nous-clawds4/tapestry
+#   tapestry.brainstorm.world
+#   staging.brainstorm.world
+#   tags.brainstorm.world
+#   communities.brainstorm.world
+#   magic-carpet.brainstorm.world
+#   curate.brainstorm.world
+#
+# Backend APIs - github.com/NosFabrica/brainstorm_server
+#   api.brainstorm.world
+#   search.brainstorm.world
+#   brainstormserver.nosfabrica.com
+#   brainstormserver-staging.nosfabrica.com
+#
+# nostr relays - strfry, github.com/hoytech/strfry
+#   scores.brainstorm.world
+#   nip85.brainstorm.world
+#   dcosl.brainstorm.world
+#   nip85.nosfabrica.com
+#   nip85-staging.nosfabrica.com
+#
+# Any *.brainstorm.world or *.nosfabrica.com host not listed above is
+# not operated by us.
+# ---------------------------------------------------------------------
+
+Contact: https://github.com/NosFabrica/Brainstorm-UI/security/advisories/new
+Expires: 2027-08-11T00:00:00.000Z
+Preferred-Languages: en
+Policy: https://github.com/NosFabrica/Brainstorm-UI/blob/main/SECURITY.md

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,16 +33,25 @@ fi
 # OMITTED otherwise — the field is optional, which makes absence safe and a
 # wrong value actively harmful.
 #
-# CANONICAL_HOST is validated as a bare hostname before use. A typo that
-# produced a malformed URI would invalidate the whole document, so a value that
-# does not look like a hostname is dropped (with a warning) rather than emitted.
+# CANONICAL_HOSTS accepts a comma- or space-separated LIST, and emits one
+# Canonical line per host. This is required, not a convenience: a single
+# deployment serves more than one hostname (prod-values.yaml lists both
+# brainstorm.nosfabrica.com and brainstorm.world under domains.ui), and a
+# document naming only one of them is invalid on the other. RFC 9116 permits
+# repeated Canonical fields for exactly this case.
+#
+# Each host is validated as a bare hostname. A typo that produced a malformed
+# URI would invalidate the whole document, so a bad entry is dropped with a
+# warning rather than emitted.
 SECURITY_FILE="/usr/share/nginx/html/.well-known/security.txt"
-if [ -f "$SECURITY_FILE" ] && [ -n "${CANONICAL_HOST}" ]; then
-  if printf '%s' "${CANONICAL_HOST}" | grep -Eq '^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$'; then
-    printf 'Canonical: https://%s/.well-known/security.txt\n' "${CANONICAL_HOST}" >> "$SECURITY_FILE"
-  else
-    echo "[entrypoint] WARN: CANONICAL_HOST='${CANONICAL_HOST}' is not a bare hostname; omitting Canonical from security.txt" >&2
-  fi
+if [ -f "$SECURITY_FILE" ] && [ -n "${CANONICAL_HOSTS}" ]; then
+  for host in $(printf '%s' "${CANONICAL_HOSTS}" | tr ',' ' '); do
+    if printf '%s' "$host" | grep -Eq '^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$'; then
+      printf 'Canonical: https://%s/.well-known/security.txt\n' "$host" >> "$SECURITY_FILE"
+    else
+      echo "[entrypoint] WARN: CANONICAL_HOSTS entry '$host' is not a bare hostname; omitting it from security.txt" >&2
+    fi
+  done
 fi
 # -----------------------------------------------------------------------------
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,4 +12,38 @@ if [ -f "$CONFIG_FILE" ]; then
   done
 fi
 
+# --- Site trust signals ------------------------------------------------------
+# robots.txt and the Canonical line of security.txt are per-deployment, but the
+# image is shared across production, the production alias, and staging. Both are
+# therefore written here at container start rather than baked into the build.
+
+# robots.txt — fails CLOSED. Only a deployment that explicitly sets
+# ALLOW_INDEXING=true is indexable; everything else disallows crawling, so a
+# staging deployment can never compete with production in search results.
+ROBOTS_FILE="/usr/share/nginx/html/robots.txt"
+if [ "${ALLOW_INDEXING}" = "true" ]; then
+  printf 'User-agent: *\nAllow: /\n' > "$ROBOTS_FILE"
+else
+  printf 'User-agent: *\nDisallow: /\n' > "$ROBOTS_FILE"
+fi
+
+# security.txt Canonical — RFC 9116 §2.5.2: if the URL the file was retrieved
+# from matches none of its Canonical fields, the contents SHOULD NOT be trusted.
+# So the field is appended only when a public hostname is configured, and
+# OMITTED otherwise — the field is optional, which makes absence safe and a
+# wrong value actively harmful.
+#
+# CANONICAL_HOST is validated as a bare hostname before use. A typo that
+# produced a malformed URI would invalidate the whole document, so a value that
+# does not look like a hostname is dropped (with a warning) rather than emitted.
+SECURITY_FILE="/usr/share/nginx/html/.well-known/security.txt"
+if [ -f "$SECURITY_FILE" ] && [ -n "${CANONICAL_HOST}" ]; then
+  if printf '%s' "${CANONICAL_HOST}" | grep -Eq '^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$'; then
+    printf 'Canonical: https://%s/.well-known/security.txt\n' "${CANONICAL_HOST}" >> "$SECURITY_FILE"
+  else
+    echo "[entrypoint] WARN: CANONICAL_HOST='${CANONICAL_HOST}' is not a bare hostname; omitting Canonical from security.txt" >&2
+  fi
+fi
+# -----------------------------------------------------------------------------
+
 exec "$@"

--- a/docs/estate-audit.md
+++ b/docs/estate-audit.md
@@ -1,0 +1,172 @@
+# Brainstorm domain estate — trust-signal audit
+
+**Surveyed:** 2026-08-11 / 2026-08-12 · **18 live hostnames · 4 fleets · 3 codebases · 2 GitHub orgs**
+
+Every status below reflects a response observed directly, not inferred.
+
+---
+
+## The diagnosis
+
+Reputation scanners began flagging much of the estate as unsafe. The working theory was that the
+deployments look like copies of each other. That is true, but it isn't what a scanner keys on.
+
+Every host answered `200 OK` with the same contentless single-page-app shell for **every** path
+requested — including paths that should never exist.
+
+What an automated scanner saw:
+
+- `/robots.txt` returned HTML, not a robots file — on all 18 hosts
+- `/.well-known/security.txt` returned HTML — no host published a security contact
+- `/.env`, `/wp-login.php`, and arbitrary nonsense all returned `200`
+- Ten hostnames resolved to a single IP (`74.208.86.220`), several serving byte-identical markup
+- The served HTML was ~400 bytes of boilerplate, so crawlers saw no distinguishing text anywhere
+
+Taken together that is close to the textbook fingerprint of a bulk-generated phishing estate. The
+backends were the exception — they already returned honest 404s, which is why they are the only part
+of the estate that was already clean.
+
+One correction worth recording: the blocklist involved is minor, and being on it is probably not
+costing real traffic today. The signals it reacted to are the same ones consumed by the reputation
+systems that *do* matter, which is the reason to fix them.
+
+---
+
+## The estate
+
+### Product UI — `NosFabrica/Brainstorm-UI` (nginx)
+
+| Host | IP | Role | Status |
+|---|---|---|---|
+| `brainstorm.world` | 74.208.86.220 | Production | PR #43 open |
+| `brainstorm.nosfabrica.com` | 74.208.86.220 | Production alias | PR #43 open |
+| `brainstorm-staging.nosfabrica.com` | 74.208.86.220 | Staging | PR #43 open |
+
+### R&D UI — `nous-clawds4/tapestry` (Express)
+
+| Host | IP | Role | Status |
+|---|---|---|---|
+| `tapestry.brainstorm.world` | 159.203.150.156 | Reference deploy | ✅ Live |
+| `staging.brainstorm.world` | 137.184.219.255 | Pre-production | ✅ Live |
+| `tags.brainstorm.world` | 24.199.72.90 | Sandbox | ✅ Live |
+| `communities.brainstorm.world` | 174.138.108.124 | Sandbox | ✅ Live |
+| `magic-carpet.brainstorm.world` | 68.183.114.219 | Sandbox | ✅ Live |
+| `curate.brainstorm.world` | 159.203.159.219 | Sandbox | ✅ Live |
+
+### nostr relays — strfry
+
+| Host | IP | Role | Status |
+|---|---|---|---|
+| `scores.brainstorm.world` | 74.208.86.220 | Public relay | Patch ready (k8s) |
+| `nip85.nosfabrica.com` | 74.208.86.220 | NIP-85 | Patch ready (k8s) |
+| `nip85-staging.nosfabrica.com` | 74.208.86.220 | NIP-85 staging | Patch ready (k8s) |
+| `nip85.brainstorm.world` | 129.212.133.141 | Trusted Assertions | ⚠️ Standalone — manual |
+| `dcosl.brainstorm.world` | 129.212.135.199 | Decentralized lists | ⚠️ Standalone — manual |
+
+### Backend APIs — `NosFabrica/brainstorm_server`
+
+| Host | IP | Role | Status |
+|---|---|---|---|
+| `api.brainstorm.world` | 74.208.86.220 | Production API | ✅ 404s correctly |
+| `search.brainstorm.world` | 74.208.86.220 | Search API | ✅ 404s correctly |
+| `brainstormserver.nosfabrica.com` | 74.208.86.220 | Production API | ✅ 404s correctly |
+| `brainstormserver-staging.nosfabrica.com` | 74.208.86.220 | Staging API | ✅ 404s correctly |
+
+**Dead DNS.** Five hostnames referenced in source have no A record: `lists.`, `npub.`,
+`wot.brainstorm.world`, `nip85-staging.brainstorm.world`, `relay-staging.brainstorm.world`. Harmless
+on its own, but evidence the inventory drifts unnoticed — which matters now that the inventory is
+published as an ownership attestation.
+
+---
+
+## What changed
+
+The same three things everywhere: publish a security contact, tell crawlers the truth, and stop
+answering `200` to paths that don't exist. The implementation differs because the serving layer does.
+
+| Codebase | Approach | State |
+|---|---|---|
+| `nous-clawds4/tapestry` | Express — pure module renders both documents; shape-based rule ahead of the SPA catch-all | ✅ Live on all six hosts |
+| `NosFabrica/Brainstorm-UI` | nginx — exact-match locations, deny rule, per-deployment values at container start | PR #43 |
+| `NosFabrica/brainstorm-k8s` | Ingress — relays have no app layer, so both documents are served at the edge | Patch, no PR (see below) |
+
+---
+
+## Two defects the acceptance criteria would have missed
+
+Both were found by probing past what was specified, and neither violated a written criterion.
+
+**The config that never arrived.** The indexing flag was read correctly by the application and set
+correctly in the deployment — but was absent from the container's environment list, so it never
+crossed the boundary between them. Production would have silently kept telling search engines not to
+crawl it, with no symptom reproducible locally.
+
+**The rule that was one escape away.** Express does not percent-decode request paths. Every literal
+probe path returned 404 as designed, while `/%2Eenv` sailed through and returned `200` — defeating
+the whole feature for any scanner that encodes its probes.
+
+A third issue was caught before it could bite: the rule blocking unknown `/.well-known/` paths also
+matched `/.well-known/acme-challenge/`, used to issue and renew TLS certificates. Challenges resolve
+above the application layer today, so nothing was broken — but had that changed, certificate
+**renewal** would have failed silently for weeks and then expired TLS on every host at once. It is
+now explicitly exempt in both codebases. `virtualserver.yaml` already carried a comment warning about
+exactly this, which is where it was spotted.
+
+---
+
+## What NosFabrica needs to do
+
+`brainstorm-k8s` is private with forking disabled and read-only access, so its change could not be
+submitted as a pull request. It is supplied as a two-commit patch. These steps are ordered because
+the later ones depend on the earlier.
+
+1. **Enable private vulnerability reporting** on `Brainstorm-UI` and `brainstorm_server`
+   (Settings → Code security). Both are currently off, which means the security contact published by
+   these changes points at a channel that does not accept reports.
+
+2. **Apply the k8s patch and merge PR #43 together.** The PR reads two values — `ALLOW_INDEXING` and
+   `CANONICAL_HOSTS` — that only the chart supplies. Merging the PR alone leaves both unset: safe,
+   but production will not be indexable.
+
+   ```bash
+   git am < brainstorm-k8s-site-trust.patch
+   ```
+
+3. **Fix the two standalone relays by hand.** `nip85.brainstorm.world` and `dcosl.brainstorm.world`
+   run on their own droplets and are not in the chart, so nothing above reaches them. Each needs both
+   documents served from its host nginx, ahead of the strfry pass-through.
+
+4. **Verify per host.**
+
+   ```bash
+   curl -sI https://HOST/.well-known/security.txt | grep -i content-type   # text/plain
+   curl -s -o /dev/null -w '%{http_code}\n' https://HOST/.env              # 404
+   ```
+
+---
+
+## Decisions left open
+
+**The relay operator pubkey.** Three relays advertise no operator identity in their NIP-11 document.
+For a nostr relay that is a stronger ownership signal than a security contact. The two standalone
+relays already publish `e5272de914bd301755c439b88e6959a43c9d2664831f093c51e9c799a16a102f`. It was
+deliberately left blank in the chart rather than copied across — it is an identity assertion, and a
+wrong value is worse than an absent one.
+
+**An unrecognized deployment.** The chart's arrowhead values file points at
+`brainstorm-staging.relay.tools` — a third domain outside both `brainstorm.world` and
+`nosfabrica.com`. It is not named in the ownership attestation these changes publish. If it is an
+official deployment, the attestation should list it.
+
+---
+
+## Renewal obligation
+
+The published documents carry `Expires: 2027-08-11`. RFC 9116 treats an expired `security.txt` as
+**invalid** — a scanner that fetches a stale one gets a negative signal from a file published to earn
+a positive one. All three copies (tapestry, Brainstorm-UI, the k8s chart helper) need refreshing
+before that date, along with a re-check that the hostname inventory above is still accurate.
+
+In `nous-clawds4/tapestry` the alarm is already wired: test `U1` asserts `Expires` is in the future,
+so its suite goes red on the day and stays red until someone acts. The other two copies have no such
+alarm.

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,44 @@ server {
         try_files $uri =404;
     }
 
+    # ---- Site trust signals -------------------------------------------------
+    # Both documents are real files on disk (robots.txt and the Canonical line
+    # of security.txt are written by docker-entrypoint.sh at container start).
+    # Exact-match locations, so they take precedence over the dotfile rule below.
+    location = /robots.txt {
+        default_type text/plain;
+        charset utf-8;
+        try_files $uri =404;
+    }
+
+    location = /.well-known/security.txt {
+        default_type text/plain;
+        charset utf-8;
+        try_files $uri =404;
+    }
+
+    # Probe and config-shaped paths must NOT fall through to the SPA. A host
+    # that answers 200 to /.env and /wp-login.php reads to a reputation scanner
+    # as a parked or cloned site.
+    #
+    # `try_files $uri =404` rather than a bare `return 404`: a regex location
+    # takes over the request entirely, so a bare return would 404 a real file
+    # with one of these extensions. This serves it if it exists, 404s if not —
+    # what it must never do is fall back to index.html.
+    #
+    # `js`, `css`, `map`, and image extensions are deliberately absent so that
+    # /assets/ keeps its immutable caching and real assets are untouched.
+    location ~* \.(php|asp|aspx|jsp|cgi|sql|bak|ini|conf|sh|yml|yaml|env|json|xml|txt)$ {
+        try_files $uri =404;
+    }
+
+    # Dotfiles and dot-directories (/.env, /.git/config, unhandled
+    # /.well-known/*). No SPA route has a dot-prefixed segment.
+    location ~ /\. {
+        return 404;
+    }
+    # -------------------------------------------------------------------------
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,21 @@ server {
     }
 
     # ---- Site trust signals -------------------------------------------------
+    # ACME HTTP-01 challenges are exempt from every rule below. cluster-issuers
+    # .yaml uses an http01 solver, so cert-manager answers
+    # /.well-known/acme-challenge/<token> over plain HTTP; a 404 there fails
+    # certificate issuance AND renewal, silently, until TLS expires on every
+    # host at once. `^~` so this prefix wins outright over the regex locations
+    # further down (nginx stops looking once a `^~` prefix match is found).
+    #
+    # Today the challenge is resolved above this container by cert-manager's
+    # solver Ingress, so this block changes nothing. It exists so that a future
+    # change in how challenges are routed cannot be broken by the rules below.
+    location ^~ /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+
+
     # Both documents are real files on disk (robots.txt and the Canonical line
     # of security.txt are written by docker-entrypoint.sh at container start).
     # Exact-match locations, so they take precedence over the dotfile rule below.


### PR DESCRIPTION
## Why

Reputation scanners have flagged much of the Brainstorm estate as unsafe. A probe of all 18 live hosts on 2026-08-11 found a concrete shared defect rather than a cosmetic resemblance.

Every path on `brainstorm.world`, `brainstorm.nosfabrica.com`, and `brainstorm-staging.nosfabrica.com` returns **200 with the SPA shell** — including `/robots.txt`, `/.well-known/security.txt`, `/.env`, and arbitrary nonsense paths. Nothing ever 404s.

Combined with three near-identical hostnames on one IP (`74.208.86.220`, which carries ten names in total), a contentless SPA shell, and no published ownership or contact information anywhere, that is close to the standard automated fingerprint for a bulk-generated clone farm.

The backends already behave correctly — `api.brainstorm.world` and `brainstormserver*.nosfabrica.com` return clean 404s. This PR brings the UI in line.

## What changed

### `nginx.conf`

- `/robots.txt` and `/.well-known/security.txt` are served as `text/plain` via **exact-match** locations, which take precedence over the dotfile rule below them.
- Probe and config-shaped paths get a genuine 404 instead of the SPA shell.
- Dotfiles and dot-directories (`/.env`, `/.git/config`, unhandled `/.well-known/*`) 404.

Two deliberate choices worth a reviewer's attention:

1. **`try_files $uri =404` rather than a bare `return 404`.** A regex location in nginx takes over the request entirely, so a bare `return 404` would 404 a *real* file such as `/manifest.json`. This form serves the file when it exists and 404s when it doesn't — what it must never do is fall back to `index.html`.
2. **`js`, `css`, `map`, and image extensions are deliberately absent** from the deny list, so `/assets/` keeps its immutable caching and no real asset is ever at risk.

### `docker-entrypoint.sh`

The image is shared across production, the production alias, and staging, so neither of these can be a static file baked into the build:

- **`robots.txt` is generated at container start from `ALLOW_INDEXING`, and fails CLOSED.** Only a deployment that explicitly sets `ALLOW_INDEXING=true` is indexable — so staging can never accidentally compete with production in search results.
- **The `security.txt` `Canonical` line is appended from `CANONICAL_HOSTS`, and omitted when unset.** RFC 9116 §2.5.2: a document whose retrieval URL matches none of its `Canonical` fields SHOULD NOT be trusted, so a guessed value is worse than an absent one. The value is validated as a bare hostname before use — a malformed value is dropped with a warning rather than emitted.

### `client/public/.well-known/security.txt` and `SECURITY.md`

An RFC 9116 document carrying an ownership attestation that names every official host across all four fleets (product UI, R&D UI, backend APIs, relays). That list is the substantive, machine-readable answer to *"these domains look like clones of each other"*, and it closes by claiming both apex domains outright: `brainstorm.world` and `nosfabrica.com` are ours, so any host under either is operated by us — the list is a current inventory, not an exhaustive claim — while a site resembling Brainstorm on any *other* domain is not affiliated with us.

## Verification

Run against a real `nginx:1.31-alpine` with this exact config and a representative `dist/` tree:

| Path | Result | |
|---|---|---|
| `/`, `/pins`, `/user/abc123` | 200 `text/html` | SPA intact |
| `/pin/my.pinned.tag` | 200 `text/html` | dotted route param preserved |
| `/assets/index-abc123.js` | 200 `application/javascript` | |
| `/assets/index-abc123.js.map` | 200 | source maps unaffected |
| `/manifest.json` | **200** | real file with a denied extension |
| `/missing.json` | 404 | does not fall back to the SPA |
| `/robots.txt` | 200 `text/plain; charset=utf-8` | |
| `/.well-known/security.txt` | 200 `text/plain; charset=utf-8` | |
| `/.env`, `/wp-login.php`, `/config.json`, `/backup.sql`, `/settings.ini`, `/docker-compose.yml`, `/sitemap.xml`, `/index.asp` | 404 | |
| `/.git/config`, `/.well-known/nonsense` | 404 | |

The entrypoint was exercised across seven `ALLOW_INDEXING` × `CANONICAL_HOSTS` combinations:

| `ALLOW_INDEXING` | `CANONICAL_HOSTS` | robots.txt | Canonical |
|---|---|---|---|
| unset | unset | `Disallow: /` | omitted |
| `true` | `brainstorm.world` | `Allow: /` | `brainstorm.world` |
| unset | `brainstorm.nosfabrica.com` | `Disallow: /` | `brainstorm.nosfabrica.com` |
| `false` | `brainstorm-staging.nosfabrica.com` | `Disallow: /` | `brainstorm-staging.nosfabrica.com` |
| `true` | unset | `Allow: /` | omitted |
| `true` | `not a hostname` | `Allow: /` | **omitted** (validation) |
| `TRUE` | `brainstorm.world` | `Disallow: /` | `brainstorm.world` |

Note the last row: the comparison is exact, so `TRUE` fails closed. `ALLOW_INDEXING` must be lowercase `true`.

## Required before / with merge

- [ ] **Enable private vulnerability reporting** on this repository (Settings → Code security). The `Contact:` field points at `/security/advisories/new`, which will not offer outside researchers a reporting button until this is on. Shipping without it publishes a security contact that does not work. Same applies to `brainstorm_server` when its `security.txt` lands.
- [ ] **Set `ALLOW_INDEXING=true` in the production deployment only.** Without it, `brainstorm.world` serves `Disallow: /` and drops out of search results. This is a config change in `brainstorm-k8s`, not in this repo — **these two changes must land together.**
- [ ] **Set `CANONICAL_HOSTS` per deployment** (`brainstorm.world`, `brainstorm.nosfabrica.com`, `brainstorm-staging.nosfabrica.com`). Safe to omit — the field is simply absent — but the anti-tampering property is lost.
- [ ] After deploy, confirm on each host: `curl -sI https://<host>/.well-known/security.txt` returns `text/plain`, and `curl -s -o /dev/null -w '%{http_code}' https://<host>/.env` returns 404.

## Not included

- The five strfry relays (`scores.`, `nip85.`, `dcosl.brainstorm.world`, `nip85.`, `nip85-staging.nosfabrica.com`) have the same defect — they serve strfry's landing page for every path — and three of them advertise the generic NIP-11 name `"strfry"` with no `contact` and no `pubkey`. Tracked separately.
- `brainstorm_server` needs its own `security.txt`; its 404 behavior is already correct.
- Server-side rendering. The SPA shell being contentless to crawlers is a real remaining signal, but a much larger piece of work.

## Related

The matching change for the R&D fleet is in `nous-clawds4/tapestry` (six hosts, same defect, Express rather than nginx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** `CANONICAL_HOSTS` (renamed from `CANONICAL_HOST`) now takes a **list**. `prod-values.yaml` serves `brainstorm.nosfabrica.com` and `brainstorm.world` from one deployment, and a document naming only one is invalid on the other under RFC 9116 §2.5.2. Set it to the full list for each deployment, e.g. `CANONICAL_HOSTS=brainstorm.world,brainstorm.nosfabrica.com`.

Also added: `/.well-known/acme-challenge/` is now explicitly exempt from every rule here. `cluster-issuers.yaml` uses an `http01` solver, and a 404 on that path would fail certificate renewal silently until TLS expired on every host at once. It resolves above this container today, so this changes nothing in practice — it exists so a future routing change cannot be broken by these rules.

