### PR TITLE
docs: point to the brainstorm-k8s staging workflow guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,11 @@ New UI **must** use the shared primitives instead of hand-rolling styles — thi
 - Alerts → `ui/alert.tsx`; tabs → `ui/tabs.tsx`; buttons → `ui/button.tsx`
 
 Anchored to the designer's brand-guidelines p17 "UI Foundations" sheet. Full guide + what stays bespoke: `docs/design-system.md`. Interface icons are lucide today (guidelines spec Phosphor — migration deferred, not a bug).
+
+## Deploying to staging
+
+CI builds an image per branch of this repo; staging pins one of those tags
+(`ui.image.tag` in brainstorm-k8s). The branch/PR/pin workflow — including
+whether to join the current staging branch or start a new cycle — is
+documented in
+[brainstorm-k8s `docs/staging-workflow.md`](https://github.com/NosFabrica/brainstorm-k8s/blob/master/docs/staging-workflow.md).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 `docker build -t brnstui --build-arg VITE_API_URL=https://api.example123.com --build-arg VITE_NIP85_RELAY_URL=wss://nip85.example.com .`
 
 `docker run -d -p 3000:3000 --name brainstorm-ui brnstui`
+
+## Deploying to staging
+
+Staging runs images built by CI from branches of this repo
+(`ghcr.io/nosfabrica/brainstorm-ui`), pinned and rolled out via the
+[brainstorm-k8s](https://github.com/NosFabrica/brainstorm-k8s) charts
+(`ui.image.tag` + `./deploy_staging.sh --ui`). The full branch/PR/pin
+workflow — including how to decide whether to join the current staging branch
+or start a new cycle — is documented in
+[brainstorm-k8s `docs/staging-workflow.md`](https://github.com/NosFabrica/brainstorm-k8s/blob/master/docs/staging-workflow.md).


### PR DESCRIPTION
Docs-only. Adds a "Deploying to staging" pointer to README and CLAUDE.md, referencing [brainstorm-k8s `docs/staging-workflow.md`](https://github.com/NosFabrica/brainstorm-k8s/blob/master/docs/staging-workflow.md) — the branch/PR/image-tag-pin workflow for getting a feature onto the staging cluster (written after the 2026-08-16 brainstorm_server Open Ranking cycle; applies identically to the UI via `ui.image.tag`).

Deliberately targets `main` rather than the live `feat/applesauce` staging cycle, so it doesn't touch anyone's in-flight work — merge whenever convenient. A `main` merge rebuilds `latest` with an identical-code, docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)