### PR TITLE
Ask for the NIP-85 (kind 10040) publish at calculate-time

### DIFF
--- a/client/src/accounts/login-flow.ts
+++ b/client/src/accounts/login-flow.ts
@@ -97,11 +97,23 @@ async function completeLogin(account: BrainstormAccount, token: string): Promise
 
   // Load the authoritative contact list (kind 3) once at login and persist it as
   // the known-follows floor, so the follow handlers can never publish a list
-  // shorter than what the user actually follows (wipe guard). Fire-and-forget.
-  void import("@/services/socialActions")
-    .then((m) => m.fetchContactList(pubkey))
-    .then((ev) => { if (ev) recordFollowList(pubkey, ev as any); })
-    .catch(() => {});
+  // shorter than what the user actually follows (wipe guard). Fire-and-forget,
+  // but not one-shot: a miss warms the outbox relay list (so the retry asks the
+  // user's real write relays, not just the hardcoded profile set) and looks once
+  // more — a silently empty floor is what used to hand existing users the
+  // new-user follow picker.
+  void (async () => {
+    try {
+      const { fetchContactList } = await import("@/services/socialActions");
+      let ev = await fetchContactList(pubkey);
+      if (!ev) {
+        const { fetchOutboxRelayList } = await import("@/services/nostr");
+        await fetchOutboxRelayList(pubkey).catch(() => undefined);
+        ev = await fetchContactList(pubkey);
+      }
+      if (ev) recordFollowList(pubkey, ev as any);
+    } catch { /* the dashboard's relay verification is the fallback */ }
+  })();
 
   // Start fetching the user's profile metadata (kind 0) immediately at login
   // instead of deferring it to the dashboard. This removes the dashboard-mount

--- a/client/src/components/ActivateBrainstormModal.tsx
+++ b/client/src/components/ActivateBrainstormModal.tsx
@@ -7,12 +7,10 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { BrainLogo } from "@/components/BrainLogo";
-import { ChevronDown, Check, Loader2, ExternalLink, AlertCircle, FileSignature, HeartHandshake, Rocket } from "lucide-react";
-import type { NostrEvent } from "applesauce-core/helpers";
-import { publishToRelays, signNip85, getNip85RelayUrl, fetchTrustProviderList } from "@/services/nostr";
-import { isUnlockCancelled } from "@/accounts/local-signer";
+import { ChevronDown, Check, Loader2, ExternalLink, AlertCircle } from "lucide-react";
+import { checkExistingTrustProvider, publishBrainstormTrustAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
-import { markNip85Activated } from "@/lib/nip85Activation";
+import { nip85ExplainerSections } from "@/components/nip85Explainer";
 
 interface ActivateBrainstormModalProps {
   open: boolean;
@@ -20,8 +18,6 @@ interface ActivateBrainstormModalProps {
   serviceKey: string;
   onActivated: () => void;
 }
-
-const NIP85_URL = "https://github.com/nostr-protocol/nips/blob/master/85.md";
 
 type ActivateState = "idle" | "signing" | "publishing" | "success" | "cancelled" | "error";
 
@@ -44,14 +40,10 @@ export function ActivateBrainstormModal({ open, onOpenChange, serviceKey, onActi
     if (!open) return;
     let cancelled = false;
     (async () => {
-      try {
-        if (!user?.pubkey) return;
-        const event = await fetchTrustProviderList(user.pubkey);
-        if (cancelled || !event) return;
-        const rankTag = event.tags.find((t: string[]) => t[0] === "30382:rank");
-        const target = rankTag?.[1];
-        if (target && serviceKey && target !== serviceKey) setHasOtherProvider(true);
-      } catch { /* best-effort — fall back to the generic disclaimer */ }
+      if (!user?.pubkey) return;
+      // "unknown"/"none" fall back to the generic disclaimer — best-effort.
+      const status = await checkExistingTrustProvider(user.pubkey, serviceKey);
+      if (!cancelled && status === "other") setHasOtherProvider(true);
     })();
     return () => { cancelled = true; };
     // `user` is stream-backed and null for the first renders, so the effect bails
@@ -74,43 +66,25 @@ export function ActivateBrainstormModal({ open, onOpenChange, serviceKey, onActi
       return;
     }
 
-    let nip85Relay: string;
-    try {
-      nip85Relay = getNip85RelayUrl();
-    } catch (err: any) {
-      setActivateState("error");
-      setErrorMessage(err?.message || "NIP-85 relay URL is not configured.");
-      return;
-    }
+    const result = await publishBrainstormTrustAnchor(user.pubkey, serviceKey, setActivateState);
 
-    let signedEvent: NostrEvent;
-    try {
-      signedEvent = await signNip85(serviceKey, nip85Relay);
-    } catch (err: any) {
+    if (result.status === "success") {
+      setActivateState("success");
+      setTimeout(() => {
+        onActivated();
+      }, 2000);
+    } else if (result.status === "cancelled") {
       // A declined unlock never shows as an error; an extension refusal keeps the
       // "cancelled" note it always had.
-      if (isUnlockCancelled(err)) {
+      if (result.unlockDeclined) {
         setActivateState("idle");
         return;
       }
       setActivateState("cancelled");
       setTimeout(() => setActivateState("idle"), 3000);
-      return;
-    }
-
-    setActivateState("publishing");
-
-    const result = await publishToRelays(signedEvent);
-
-    if (result.success) {
-      markNip85Activated(user.pubkey);
-      setActivateState("success");
-      setTimeout(() => {
-        onActivated();
-      }, 2000);
     } else {
       setActivateState("error");
-      setErrorMessage(result.error || "Failed to publish to relays. Please try again.");
+      setErrorMessage(result.message);
     }
   };
 
@@ -124,72 +98,7 @@ export function ActivateBrainstormModal({ open, onOpenChange, serviceKey, onActi
     onOpenChange(nextOpen);
   };
 
-  const sections = [
-    {
-      key: "what",
-      icon: <FileSignature className="h-4 w-4" />,
-      title: "What does this mean?",
-      content: (
-        <div className="space-y-3">
-          <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
-            Selecting Brainstorm as your Service Provider signs a nostr note (kind 10040)
-            that tells compatible clients where to find the scores we publish on your behalf.
-          </p>
-          <a
-            href={NIP85_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-link hover:text-brand-primary transition-colors"
-            data-testid="link-nip85-learn-more-what"
-          >
-            Learn more in NIP-85: Trusted Assertions
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        </div>
-      ),
-    },
-    {
-      key: "why",
-      icon: <HeartHandshake className="h-4 w-4" />,
-      title: "Why this matters",
-      content: (
-        <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
-          Harness your extended and trusted nostr community to help you eliminate spam and find
-          the content that best suits your interests and values. Take control over your time and
-          attention. Steer clear of the information gatekeepers and the advertisers who only see
-          you as their product!
-        </p>
-      ),
-    },
-    {
-      key: "next",
-      icon: <Rocket className="h-4 w-4" />,
-      title: "What happens next",
-      content: (
-        <div className="space-y-3">
-          <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
-            We will calculate scores for your entire nostr network, entirely from YOUR
-            perspective, using standard nostr follows, mutes, and reports. This usually takes
-            5–10 minutes.
-          </p>
-          <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
-            We next publish those scores as nostr notes (called Trusted Assertions) which makes
-            them available for use by clients and apps throughout the nostr network.
-          </p>
-          <a
-            href={NIP85_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-link hover:text-brand-primary transition-colors"
-            data-testid="link-nip85-learn-more-next"
-          >
-            Learn more about NIP-85: Trusted Assertions
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        </div>
-      ),
-    },
-  ];
+  const sections = nip85ExplainerSections;
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>

--- a/client/src/components/AutoActivateBrainstorm.tsx
+++ b/client/src/components/AutoActivateBrainstorm.tsx
@@ -1,25 +1,24 @@
 import {useEffect} from "react";
 import { useOncePerPubkey } from "@/hooks/useOncePerPubkey";
-import { ensureBrainstormTrustAnchor } from "@/services/trustAnchor";
+import { ensureBrainstormTrustAnchor, shouldAutoPublishNip85 } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { isNip85Activated } from "@/lib/nip85Activation";
 import { useSelfHistory } from "@/hooks/useSelf";
-import { identityHas } from "@/accounts/display";
 import { useHasSession } from "@/hooks/useHasSession";
 
 /**
- * New (in-app-created) accounts select Brainstorm as their Web-of-Trust provider
- * automatically — signing up here IS the consent. The kind-10040 declaration can
- * only be published once the backend assigns a `ta_pubkey` (after their first
- * score), and because these users never see the dashboard "Select Brainstorm"
- * card, a failed/interrupted publish must self-heal: on each app load, once a
- * ta_pubkey exists and the declaration isn't confirmed yet, (re)publish it.
- * `ensureBrainstormTrustAnchor` is idempotent (flag + relay check), so this is a
- * no-op once done.
+ * The cross-session self-heal for the NIP-85 declaration of any account that
+ * consented (the calculate-step consent card, or in-app signup for accounts
+ * never shown it — see `shouldAutoPublishNip85`). The calculate surfaces
+ * publish the kind-10040 immediately; when that publish was interrupted — a
+ * locked local key that couldn't sign silently, a closed tab — this effect
+ * finishes it: on each app load, once a `ta_pubkey` exists and the declaration
+ * isn't confirmed yet, (re)publish it. `ensureBrainstormTrustAnchor` is
+ * idempotent (flag + relay check), so this is a no-op once done.
  *
- * Existing / login-with-key accounts are intentionally excluded — they select
- * Brainstorm explicitly (with a replace-warning), so we never overwrite a
- * provider choice they didn't make here.
+ * Accounts that declined (or were never asked and didn't sign up here) are
+ * excluded — they select Brainstorm explicitly via the dashboard card (with a
+ * replace-warning), so we never overwrite a provider choice they didn't make.
  *
  * Renders nothing; mount once at the app root.
  */
@@ -33,8 +32,7 @@ export function AutoActivateBrainstorm() {
   useEffect(() => {
     if (!pk || once.done(pk) || !history.isSuccess) return;
 
-    const createdInApp = identityHas(pk, "createdInApp");
-    if (!createdInApp || isNip85Activated(pk)) return; // existing user, or already activated
+    if (!shouldAutoPublishNip85(pk) || isNip85Activated(pk)) return; // no consent, or already activated
 
     const taPubkey = (history.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
     if (!taPubkey) return; // not scored yet — nothing to anchor

--- a/client/src/components/ConfirmNewFollowListDialog.tsx
+++ b/client/src/components/ConfirmNewFollowListDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmNewFollowListDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  busy?: boolean;
+}
+
+/**
+ * The one question only the user can answer before a from-scratch kind-3 is
+ * allowed: "have you ever followed anyone with this key?" Shown when
+ * `followPubkeys` returns `needsBaseConfirmation` — we found no follow list on
+ * their relays, which for an imported key is indistinguishable from a fetch
+ * that failed. Publishing anyway would replace whatever list actually exists
+ * (kind 3 is replaceable), so the destructive path requires this explicit
+ * consent. Cancel is the default; nothing has been published either way.
+ */
+export function ConfirmNewFollowListDialog({ open, onCancel, onConfirm, busy = false }: ConfirmNewFollowListDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={(next) => { if (!next && !busy) onCancel(); }}>
+      <AlertDialogContent data-testid="dialog-confirm-new-follow-list">
+        <AlertDialogHeader>
+          <AlertDialogTitle>We couldn't find an existing follow list</AlertDialogTitle>
+          <AlertDialogDescription>
+            We checked your relays and couldn't find a follow list for this key. If you've
+            followed people before — here or in another app — publishing now could replace
+            that list. Cancel and try again in a moment, or continue only if you've never
+            followed anyone with this key.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={busy} data-testid="button-new-follow-list-cancel">
+            Cancel — try again later
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => { e.preventDefault(); onConfirm(); }}
+            disabled={busy}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            data-testid="button-new-follow-list-confirm"
+          >
+            I've never followed anyone — continue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/client/src/components/FollowToCalculateCard.test.tsx
+++ b/client/src/components/FollowToCalculateCard.test.tsx
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/utils";
+
+const PUBKEY = "a".repeat(64);
+
+const toast = vi.fn();
+const followPubkeys = vi.fn(async (_pks: string[], _opts?: { allowFromScratch?: boolean }): Promise<Record<string, unknown>> => ({ success: true }));
+
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+vi.mock("@/hooks/useActiveAccountDisplay", () => ({
+  useActiveAccountDisplay: () => ({ pubkey: PUBKEY, npub: "npub1lira", displayName: "Lira" }),
+}));
+vi.mock("@/services/socialActions", () => ({
+  followPubkeys: (...a: unknown[]) => followPubkeys(...(a as [string[]])),
+}));
+vi.mock("@/services/trustAnchor", () => ({
+  triggerScoringAndAnchor: vi.fn(async () => {}),
+  publishBrainstormTrustAnchor: vi.fn(async () => ({ status: "success" })),
+  checkExistingTrustProvider: vi.fn(async () => "none"),
+}));
+vi.mock("@/hooks/useSelf", () => ({
+  useSelfHistory: () => ({ data: undefined, isSuccess: false }),
+}));
+vi.mock("@/lib/nip85Activation", () => ({ isNip85Activated: () => false }));
+vi.mock("@/services/nostr", () => ({
+  fetchProfileMap: vi.fn(async () => new Map()),
+  SEED_FOLLOW_HEX: "b".repeat(64),
+}));
+vi.mock("@/lib/profileSearch", () => ({ searchByText: vi.fn(async () => ({ results: [] })) }));
+vi.mock("@/components/PersonRow", () => ({
+  PersonRow: ({ person }: { person: { pubkey: string } }) => <div data-testid={`row-${person.pubkey.slice(0, 8)}`} />,
+}));
+
+import { FollowToCalculateCard } from "./FollowToCalculateCard";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  followPubkeys.mockResolvedValue({ success: true });
+});
+
+/**
+ * The from-scratch confirmation, end to end from the card: `followPubkeys`
+ * refusing with `needsBaseConfirmation` must surface the dialog rather than a
+ * generic failure, and only an explicit confirm may retry with
+ * `allowFromScratch` — cancel leaves everything unpublished.
+ */
+describe("the first-follow-list confirmation", () => {
+  it("opens the dialog instead of toasting a failure", async () => {
+    followPubkeys.mockResolvedValue({ success: false, needsBaseConfirmation: true, error: "unconfirmed" });
+    const onDone = vi.fn();
+    renderWithProviders(<FollowToCalculateCard onDone={onDone} />);
+
+    fireEvent.click(screen.getByTestId("follow-card-commit"));
+
+    await waitFor(() => expect(screen.getByTestId("dialog-confirm-new-follow-list")).toBeInTheDocument());
+    expect(onDone).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" }));
+  });
+
+  it("confirm retries with allowFromScratch and completes the flow", async () => {
+    followPubkeys.mockResolvedValueOnce({ success: false, needsBaseConfirmation: true, error: "unconfirmed" });
+    const onDone = vi.fn();
+    renderWithProviders(<FollowToCalculateCard onDone={onDone} />);
+
+    fireEvent.click(screen.getByTestId("follow-card-commit"));
+    await waitFor(() => expect(screen.getByTestId("dialog-confirm-new-follow-list")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("button-new-follow-list-confirm"));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(followPubkeys).toHaveBeenLastCalledWith(expect.any(Array), { allowFromScratch: true });
+  });
+
+  it("cancel closes the dialog and publishes nothing", async () => {
+    followPubkeys.mockResolvedValue({ success: false, needsBaseConfirmation: true, error: "unconfirmed" });
+    const onDone = vi.fn();
+    renderWithProviders(<FollowToCalculateCard onDone={onDone} />);
+
+    fireEvent.click(screen.getByTestId("follow-card-commit"));
+    await waitFor(() => expect(screen.getByTestId("dialog-confirm-new-follow-list")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("button-new-follow-list-cancel"));
+
+    await waitFor(() => expect(screen.queryByTestId("dialog-confirm-new-follow-list")).not.toBeInTheDocument());
+    expect(followPubkeys).toHaveBeenCalledTimes(1);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("a plain success never shows the dialog", async () => {
+    const onDone = vi.fn();
+    renderWithProviders(<FollowToCalculateCard onDone={onDone} />);
+
+    fireEvent.click(screen.getByTestId("follow-card-commit"));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(screen.queryByTestId("dialog-confirm-new-follow-list")).not.toBeInTheDocument();
+    expect(followPubkeys).toHaveBeenCalledWith(expect.any(Array), undefined);
+  });
+});

--- a/client/src/components/FollowToCalculateCard.tsx
+++ b/client/src/components/FollowToCalculateCard.tsx
@@ -3,10 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import { Loader2, ArrowRight, Search as SearchIcon, X, Users } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { PersonRow, type PersonLite } from "@/components/PersonRow";
+import { Nip85ConsentCard } from "@/components/Nip85ConsentCard";
 import { SUGGESTED_ACCOUNTS } from "@/lib/suggestedAccounts";
 import { fetchProfileMap, SEED_FOLLOW_HEX } from "@/services/nostr";
-import { triggerScoringAndAnchor } from "@/services/trustAnchor";
+import { publishBrainstormTrustAnchor, triggerScoringAndAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
+import { useSelfHistory } from "@/hooks/useSelf";
+import { isNip85Activated } from "@/lib/nip85Activation";
 import { followPubkeys } from "@/services/socialActions";
 import { searchByText, type SearchResult } from "@/lib/profileSearch";
 import { DefaultAvatarImg } from "@/components/share/DefaultAvatarImg";
@@ -109,6 +112,13 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
 
   const count = selected.size;
 
+  // The NIP-85 ask rides with the calculate commit (see Nip85ConsentCard). The
+  // service key already exists server-side, so with consent the kind-10040 is
+  // signed right here while the signer is warm from the kind-3.
+  const [nip85Consent, setNip85Consent] = useState(true);
+  const historyQuery = useSelfHistory(identity?.pubkey);
+  const taPubkey = (historyQuery.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
+
   const commit = async () => {
     const pks = Array.from(selected);
     if (!pks.length || busy) return;
@@ -124,8 +134,19 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
       return;
     }
     if (identity?.pubkey) {
-      try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", identity.pubkey), String(Date.now())); } catch { /* ignore */ }
-      void triggerScoringAndAnchor(identity.pubkey);
+      const pk = identity.pubkey;
+      try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", pk), String(Date.now())); } catch { /* ignore */ }
+      void (async () => {
+        await triggerScoringAndAnchor(pk, { nip85Consent });
+        if (nip85Consent && taPubkey && !isNip85Activated(pk)) {
+          // Cancelled/failed publishes stay quiet — the consent-gated background
+          // poll and app-load self-heal finish the job.
+          const published = await publishBrainstormTrustAnchor(pk, taPubkey);
+          if (published.status === "success") {
+            toast({ title: "Scores shared", description: "Other apps can now find your Brainstorm scores." });
+          }
+        }
+      })();
     }
     toast({ title: "Calculating your trust network", description: "We're scoring your follows — this can take a few minutes." });
     onDone?.();
@@ -175,6 +196,14 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
           ))}
         </div>
       )}
+
+      <Nip85ConsentCard
+        pubkey={identity?.pubkey}
+        taPubkey={taPubkey}
+        value={nip85Consent}
+        onChange={setNip85Consent}
+        className="mt-3"
+      />
 
       {/* Selected tray + commit */}
       <div className="mt-3 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-3">

--- a/client/src/components/FollowToCalculateCard.tsx
+++ b/client/src/components/FollowToCalculateCard.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Loader2, ArrowRight, Search as SearchIcon, X, Users } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { PersonRow, type PersonLite } from "@/components/PersonRow";
+import { ConfirmNewFollowListDialog } from "@/components/ConfirmNewFollowListDialog";
 import { Nip85ConsentCard } from "@/components/Nip85ConsentCard";
 import { SUGGESTED_ACCOUNTS } from "@/lib/suggestedAccounts";
 import { fetchProfileMap, SEED_FOLLOW_HEX } from "@/services/nostr";
@@ -119,20 +120,12 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
   const historyQuery = useSelfHistory(identity?.pubkey);
   const taPubkey = (historyQuery.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
 
-  const commit = async () => {
-    const pks = Array.from(selected);
-    if (!pks.length || busy) return;
-    setBusy(true);
-    const res = await followPubkeys(pks);
-    if (res.cancelled) {
-      setBusy(false);
-      return;
-    }
-    if (!res.success) {
-      setBusy(false);
-      toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Please try again." });
-      return;
-    }
+  // followPubkeys refused to create a first-ever list without the user's say-so
+  // (imported key, nothing found on relays) — the pending picks wait on the
+  // confirmation dialog.
+  const [confirmPks, setConfirmPks] = useState<string[] | null>(null);
+
+  const afterPublish = () => {
     if (identity?.pubkey) {
       const pk = identity.pubkey;
       try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", pk), String(Date.now())); } catch { /* ignore */ }
@@ -151,6 +144,32 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
     toast({ title: "Calculating your trust network", description: "We're scoring your follows — this can take a few minutes." });
     onDone?.();
     // leave `busy` true: the card is about to be replaced by the calculating state.
+  };
+
+  const runCommit = async (pks: string[], opts?: { allowFromScratch?: boolean }) => {
+    setBusy(true);
+    const res = await followPubkeys(pks, opts);
+    if (res.cancelled) {
+      setBusy(false);
+      return;
+    }
+    if (res.needsBaseConfirmation) {
+      setBusy(false);
+      setConfirmPks(pks);
+      return;
+    }
+    if (!res.success) {
+      setBusy(false);
+      toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Please try again." });
+      return;
+    }
+    afterPublish();
+  };
+
+  const commit = () => {
+    const pks = Array.from(selected);
+    if (!pks.length || busy) return;
+    void runCommit(pks);
   };
 
   return (
@@ -240,6 +259,17 @@ export function FollowToCalculateCard({ onDone, className = "" }: { onDone?: () 
           {busy ? <><Loader2 className="h-4 w-4 animate-spin" /> Starting…</> : <>Follow {count > 0 ? count : ""} &amp; calculate my scores <ArrowRight className="h-4 w-4" /></>}
         </button>
       </div>
+
+      <ConfirmNewFollowListDialog
+        open={confirmPks !== null}
+        busy={busy}
+        onCancel={() => setConfirmPks(null)}
+        onConfirm={() => {
+          const pks = confirmPks;
+          setConfirmPks(null);
+          if (pks) void runCommit(pks, { allowFromScratch: true });
+        }}
+      />
     </div>
   );
 }

--- a/client/src/components/Nip85ConsentCard.test.tsx
+++ b/client/src/components/Nip85ConsentCard.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const checkExistingTrustProvider = vi.fn(async () => "none" as string);
+
+vi.mock("@/services/trustAnchor", () => ({
+  checkExistingTrustProvider: (...a: unknown[]) => checkExistingTrustProvider(...(a as [])),
+}));
+
+import { Nip85ConsentCard } from "./Nip85ConsentCard";
+
+const ME = "a".repeat(64);
+const TA = "f".repeat(64);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  checkExistingTrustProvider.mockResolvedValue("none");
+});
+
+describe("the ask", () => {
+  it("shows the toggle and never phones the relays when told to skip", () => {
+    render(<Nip85ConsentCard pubkey={ME} value={true} onChange={() => {}} skipProviderCheck />);
+    expect(screen.getByTestId("nip85-consent-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("nip85-consent-replace-warning")).not.toBeInTheDocument();
+    expect(checkExistingTrustProvider).not.toHaveBeenCalled();
+  });
+
+  it("reports the user's toggle", () => {
+    const onChange = vi.fn();
+    render(<Nip85ConsentCard pubkey={ME} value={true} onChange={onChange} skipProviderCheck />);
+    fireEvent.click(screen.getByTestId("nip85-consent-toggle"));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders the ask while the pre-check is still in flight — it never blocks", () => {
+    checkExistingTrustProvider.mockReturnValue(new Promise(() => {}) as never);
+    render(<Nip85ConsentCard pubkey={ME} taPubkey={TA} value={true} onChange={() => {}} />);
+    expect(screen.getByTestId("nip85-consent-toggle")).toBeInTheDocument();
+  });
+});
+
+describe("the pre-check verdicts", () => {
+  it("another provider → replace warning, and the default flips to off", async () => {
+    checkExistingTrustProvider.mockResolvedValue("other");
+    const onChange = vi.fn();
+    render(<Nip85ConsentCard pubkey={ME} taPubkey={TA} value={true} onChange={onChange} />);
+    await waitFor(() => expect(screen.getByTestId("nip85-consent-replace-warning")).toBeInTheDocument());
+    expect(checkExistingTrustProvider).toHaveBeenCalledWith(ME, TA);
+    expect(onChange).toHaveBeenCalledWith(false);
+  }, 10000);
+
+  it("already on Brainstorm → collapses to the done-chip, no toggle, consent zeroed", async () => {
+    checkExistingTrustProvider.mockResolvedValue("brainstorm");
+    const onChange = vi.fn();
+    render(<Nip85ConsentCard pubkey={ME} taPubkey={TA} value={true} onChange={onChange} />);
+    await waitFor(() => expect(screen.getByTestId("nip85-consent-already-set")).toBeInTheDocument());
+    expect(screen.queryByTestId("nip85-consent-toggle")).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("a verdict never overrides a switch the user already touched", async () => {
+    let deliver!: (v: string) => void;
+    checkExistingTrustProvider.mockReturnValue(new Promise<string>((r) => { deliver = r; }) as never);
+    const onChange = vi.fn();
+    render(<Nip85ConsentCard pubkey={ME} taPubkey={TA} value={true} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("nip85-consent-toggle")); // their call: off…
+    fireEvent.click(screen.getByTestId("nip85-consent-toggle")); // …then on again
+    onChange.mockClear();
+    deliver("other");
+    await waitFor(() => expect(screen.getByTestId("nip85-consent-replace-warning")).toBeInTheDocument());
+    expect(onChange).not.toHaveBeenCalled(); // warned, but their choice stands
+  });
+});

--- a/client/src/components/Nip85ConsentCard.tsx
+++ b/client/src/components/Nip85ConsentCard.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import { AlertCircle, Check, ChevronDown, Share2 } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Switch } from "@/components/ui/switch";
+import { checkExistingTrustProvider, type TrustProviderStatus } from "@/services/trustAnchor";
+import { nip85ExplainerSections } from "@/components/nip85Explainer";
+
+interface Nip85ConsentCardProps {
+  pubkey?: string | null;
+  /** The user's assigned Brainstorm service key, when /user/history has it. */
+  taPubkey?: string | null;
+  value: boolean;
+  onChange: (v: boolean) => void;
+  /**
+   * Skip the relay pre-check. For a key minted in this app minutes ago, a
+   * kind-10040 can't exist yet — don't spend a relay timeout looking for one
+   * in the middle of onboarding.
+   */
+  skipProviderCheck?: boolean;
+  className?: string;
+}
+
+/**
+ * The "also publish your NIP-85 declaration?" ask that sits next to every
+ * "calculate my scores" CTA. Consent is captured here, up front — the 10040 is
+ * independent of scoring and is published right at commit when the service key
+ * is known (see `publishBrainstormTrustAnchor`), instead of the old silent
+ * background publish minutes later. The pre-check reads their outbox relays: a
+ * declaration already naming Brainstorm collapses the card to a done-chip, one
+ * naming a different provider flips the default to off behind a replace
+ * warning — we never overwrite a provider choice by default.
+ */
+export function Nip85ConsentCard({
+  pubkey,
+  taPubkey,
+  value,
+  onChange,
+  skipProviderCheck = false,
+  className = "",
+}: Nip85ConsentCardProps) {
+  const [providerStatus, setProviderStatus] = useState<TrustProviderStatus | "checking">(
+    skipProviderCheck ? "none" : "checking",
+  );
+  // Once the user has touched the switch, the pre-check result must not fight
+  // their choice — it only sets defaults while the card is still untouched.
+  const touchedRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (skipProviderCheck || !pubkey) return;
+    let cancelled = false;
+    setProviderStatus("checking");
+    (async () => {
+      const status = await checkExistingTrustProvider(pubkey, taPubkey);
+      if (cancelled) return;
+      setProviderStatus(status);
+      if (touchedRef.current) return;
+      // Already declared: nothing to consent to. Another provider: opt-in only.
+      if (status === "brainstorm" || status === "other") onChangeRef.current(false);
+    })();
+    return () => { cancelled = true; };
+  }, [pubkey, taPubkey, skipProviderCheck]);
+
+  const [expanded, setExpanded] = useState(false);
+  const explainer = nip85ExplainerSections.find((s) => s.key === "what");
+
+  if (providerStatus === "brainstorm") {
+    return (
+      <Card className={`p-4 ${className}`} data-testid="nip85-consent-card">
+        <div className="flex items-center gap-2.5">
+          <Chip tone="emerald" icon={Check} data-testid="nip85-consent-already-set">Already set up</Chip>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Brainstorm is your trusted-assertions provider — other apps can already find your scores.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={`p-4 ${className}`} data-testid="nip85-consent-card">
+      <div className="flex items-start gap-3">
+        <div className="h-8 w-8 rounded-lg bg-brand-primary/10 dark:bg-brand-primary/15 border border-brand-primary/15 dark:border-brand-primary/25 flex items-center justify-center text-brand-link shrink-0">
+          <Share2 className="h-4 w-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-bold text-slate-900 dark:text-slate-100">
+            Share your scores with other apps
+          </p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+            Also signs one nostr note (NIP-85) telling compatible apps like Amethyst and Nostria
+            where to find your personalized scores. Your signer will ask you to approve it.
+          </p>
+        </div>
+        <Switch
+          checked={value}
+          onCheckedChange={(v) => {
+            touchedRef.current = true;
+            onChange(v);
+          }}
+          aria-label="Publish your NIP-85 trusted-assertions note"
+          data-testid="nip85-consent-toggle"
+        />
+      </div>
+
+      {providerStatus === "other" && (
+        <div
+          className="mt-3 flex items-start gap-2 px-3 py-2.5 rounded-xl bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/25"
+          data-testid="nip85-consent-replace-warning"
+        >
+          <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-px" />
+          <p className="text-[12px] leading-relaxed text-amber-800 dark:text-amber-200">
+            Another provider is already publishing your scores. Turning this on will{" "}
+            <strong className="font-bold">replace it</strong> with Brainstorm for your trusted
+            assertions going forward.
+          </p>
+        </div>
+      )}
+
+      {explainer && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-brand-link hover:text-brand-primary transition-colors"
+            data-testid="nip85-consent-explainer-toggle"
+          >
+            {explainer.title}
+            <ChevronDown className={`h-3.5 w-3.5 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`} />
+          </button>
+          {expanded && (
+            <div className="mt-2" data-testid="nip85-consent-explainer">
+              {explainer.content}
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/client/src/components/PostSignupCard.tsx
+++ b/client/src/components/PostSignupCard.tsx
@@ -4,6 +4,7 @@ import { X, Check, ArrowRight, Users } from "lucide-react";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { useBackupNeed } from "@/hooks/useBackupNeed";
 import { useSetupTasks } from "@/hooks/useSetupTasks";
+import { useVerifiedNoFollows } from "@/hooks/useVerifiedNoFollows";
 import { BACKUP_MESSAGE, BackupPrompt } from "@/components/BackupPrompt";
 import { dismissPostSignup, usePostSignupDismissed } from "@/lib/postSignupDismissal";
 
@@ -66,7 +67,12 @@ export function PostSignupCard() {
   // over completes the checklist, and unmounting on that click would take the
   // confirmation — and the offer to download it again — with it.
   const showFullCard = setup.eligible && (!setup.allDone || delivered);
-  const returningNeedsFollow = !setup.eligible && !networkStarted;
+  // `networkStarted` reads the local floor, which is 0 whenever the login-time
+  // kind-3 fetch failed — don't nag a user who really follows people. Only the
+  // relay-verified "none" shows the nudge; "checking" renders nothing (it's a
+  // nudge, nothing is lost) and "has-follows" suppresses it for good.
+  const followVerification = useVerifiedNoFollows(pubkey || undefined);
+  const returningNeedsFollow = !setup.eligible && !networkStarted && followVerification === "none";
 
   if (!user || dismissed) return null;
   if (!showFullCard && !returningNeedsFollow) return null;

--- a/client/src/components/nip85Explainer.tsx
+++ b/client/src/components/nip85Explainer.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { ExternalLink, FileSignature, HeartHandshake, Rocket } from "lucide-react";
+
+// The NIP-85 explainer copy, shared verbatim between the consent card shown at
+// the "calculate my scores" step and the dashboard's ActivateBrainstormModal —
+// one voice for what selecting Brainstorm as service provider means, wherever
+// the question is asked.
+
+export const NIP85_URL = "https://github.com/nostr-protocol/nips/blob/master/85.md";
+
+export interface Nip85ExplainerSection {
+  key: string;
+  icon: ReactNode;
+  title: string;
+  content: ReactNode;
+}
+
+export const nip85ExplainerSections: Nip85ExplainerSection[] = [
+  {
+    key: "what",
+    icon: <FileSignature className="h-4 w-4" />,
+    title: "What does this mean?",
+    content: (
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
+          Selecting Brainstorm as your Service Provider signs a nostr note (kind 10040)
+          that tells compatible clients where to find the scores we publish on your behalf.
+        </p>
+        <a
+          href={NIP85_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-link hover:text-brand-primary transition-colors"
+          data-testid="link-nip85-learn-more-what"
+        >
+          Learn more in NIP-85: Trusted Assertions
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    ),
+  },
+  {
+    key: "why",
+    icon: <HeartHandshake className="h-4 w-4" />,
+    title: "Why this matters",
+    content: (
+      <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
+        Harness your extended and trusted nostr community to help you eliminate spam and find
+        the content that best suits your interests and values. Take control over your time and
+        attention. Steer clear of the information gatekeepers and the advertisers who only see
+        you as their product!
+      </p>
+    ),
+  },
+  {
+    key: "next",
+    icon: <Rocket className="h-4 w-4" />,
+    title: "What happens next",
+    content: (
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
+          We will calculate scores for your entire nostr network, entirely from YOUR
+          perspective, using standard nostr follows, mutes, and reports. This usually takes
+          5–10 minutes.
+        </p>
+        <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
+          We next publish those scores as nostr notes (called Trusted Assertions) which makes
+          them available for use by clients and apps throughout the nostr network.
+        </p>
+        <a
+          href={NIP85_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-link hover:text-brand-primary transition-colors"
+          data-testid="link-nip85-learn-more-next"
+        >
+          Learn more about NIP-85: Trusted Assertions
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    ),
+  },
+];

--- a/client/src/components/share/EventThread.tsx
+++ b/client/src/components/share/EventThread.tsx
@@ -6,7 +6,7 @@ import { fetchEventsByFilter, fetchProfileMap } from "@/services/nostr";
 import { PROFILE_RELAYS } from "@/lib/relays";
 import { triggerScoringAndAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
-import { knownFollowCount } from "@/lib/followStore";
+import { useVerifiedNoFollows } from "@/hooks/useVerifiedNoFollows";
 import { apiClient } from "@/services/api";
 import { collectRefs, type MinimalEvent } from "@/lib/noteRefs";
 import { EmbeddedNoteCard } from "@/components/share/EmbeddedNoteCard";
@@ -69,10 +69,13 @@ export function EventThread({
   const buildWotHref = `/welcome${nextQ ? `?${nextQ}` : ""}`;
 
   // Existing users with follows just need to CALCULATE; brand-new accounts need to
-  // build a network first. (`knownFollowCount` is populated at login from their
-  // existing kind-3 contact list.)
+  // build a network first. Relay-verified rather than the raw local floor (which
+  // is 0 whenever the login-time fetch failed); while the check runs, offer the
+  // calculate CTA — /welcome is guarded now anyway, so misrouting there is the
+  // cheaper mistake than telling a connected user to start over.
   const myPubkey = useActiveAccountDisplay()?.pubkey || "";
-  const myFollows = myPubkey ? knownFollowCount(myPubkey) : 0;
+  const followVerification = useVerifiedNoFollows(myPubkey || undefined);
+  const hasFollows = followVerification !== "none";
   const [calcTriggered, setCalcTriggered] = useState(false);
   // Kicking off a calculation is a ~5-minute, queue-consuming operation, so it
   // asks first — same contract as the dashboard's Recalculate. This link used to
@@ -223,7 +226,7 @@ export function EventThread({
         <p className="mb-2 text-xs text-slate-500 dark:text-slate-400" data-testid="thread-filter-unlock">
           {calcTriggered ? (
             <span className="inline-flex items-center gap-1 text-brand-deep"><Loader2 className="h-3 w-3 animate-spin" /> Calculating your network — the filter switches to your perspective when it's ready.</span>
-          ) : myFollows > 0 ? (
+          ) : hasFollows ? (
             <>Filtering by the Brainstorm network.{" "}
               <button
                 type="button"

--- a/client/src/hooks/useTrustProviderStatus.ts
+++ b/client/src/hooks/useTrustProviderStatus.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { checkExistingTrustProvider, type TrustProviderStatus } from "@/services/trustAnchor";
+
+/**
+ * What the user's on-relay kind-10040 says about their trusted-assertions
+ * provider — THE authority every surface must defer to. "brainstorm" also
+ * records the local activated flag; "other" (a declaration naming a different
+ * assistant — definitive, requires taPubkey) also CLEARS it, so a badge or
+ * Settings row can never keep claiming Brainstorm over a foreign declaration.
+ * "none"/"unknown" are absence/silence: no downgrade (relays are
+ * eventually-consistent; a miss is not a deactivation).
+ *
+ * Shared by DashboardPage, SettingsPage and UserPanelPage under one query key
+ * so they can't disagree with each other.
+ */
+export function useTrustProviderStatus(
+  pubkey: string | null | undefined,
+  taPubkey: string | null | undefined,
+): UseQueryResult<TrustProviderStatus> {
+  return useQuery({
+    queryKey: ["trust-provider-status", pubkey, taPubkey],
+    queryFn: () => checkExistingTrustProvider(pubkey!, taPubkey),
+    enabled: !!pubkey && !!taPubkey,
+    retry: 2,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
+    staleTime: Infinity,
+  });
+}

--- a/client/src/hooks/useVerifiedNoFollows.test.tsx
+++ b/client/src/hooks/useVerifiedNoFollows.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const fetchContactList = vi.fn(async (): Promise<unknown> => null);
+const fetchOutboxRelayList = vi.fn(async () => undefined);
+const createdInApp = vi.fn(() => false);
+
+vi.mock("@/services/socialActions", () => ({
+  fetchContactList: (...a: unknown[]) => fetchContactList(...(a as [])),
+}));
+vi.mock("@/services/nostr", () => ({
+  fetchOutboxRelayList: (...a: unknown[]) => fetchOutboxRelayList(...(a as [])),
+}));
+vi.mock("@/accounts/display", () => ({
+  identityHas: () => createdInApp(),
+}));
+
+import { useVerifiedNoFollows } from "./useVerifiedNoFollows";
+import { knownFollowCount, recordFollowList } from "@/lib/followStore";
+
+const ME = "a".repeat(64);
+const OTHER = "b".repeat(64);
+
+const listEvent = (pubkeys: string[]) => ({
+  pubkey: ME,
+  kind: 3,
+  tags: pubkeys.map((pk) => ["p", pk]),
+  content: "",
+  created_at: 100,
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  createdInApp.mockReturnValue(false);
+  fetchContactList.mockResolvedValue(null);
+});
+
+describe("useVerifiedNoFollows", () => {
+  it("answers has-follows from the floor without touching the network", () => {
+    recordFollowList(ME, listEvent([OTHER]) as never, { authoritative: true });
+
+    const { result } = renderHook(() => useVerifiedNoFollows(ME), { wrapper });
+
+    expect(result.current).toBe("has-follows");
+    expect(fetchContactList).not.toHaveBeenCalled();
+  });
+
+  it("answers none for a key minted in this app, without touching the network", () => {
+    createdInApp.mockReturnValue(true);
+
+    const { result } = renderHook(() => useVerifiedNoFollows(ME), { wrapper });
+
+    expect(result.current).toBe("none");
+    expect(fetchContactList).not.toHaveBeenCalled();
+  });
+
+  it("finds the list on relays, repairs the floor, and answers has-follows", async () => {
+    fetchContactList.mockResolvedValue(listEvent([OTHER]));
+
+    const { result } = renderHook(() => useVerifiedNoFollows(ME), { wrapper });
+
+    expect(result.current).toBe("checking");
+    await waitFor(() => expect(result.current).toBe("has-follows"));
+    expect(knownFollowCount(ME)).toBe(1); // the floor grew — AutoScoreReturning can act
+  });
+
+  it("warms the outbox list before reading, so the real write relays are asked", async () => {
+    const { result } = renderHook(() => useVerifiedNoFollows(ME), { wrapper });
+
+    await waitFor(() => expect(result.current).toBe("none"));
+    expect(fetchOutboxRelayList).toHaveBeenCalledWith(ME);
+    const warmOrder = fetchOutboxRelayList.mock.invocationCallOrder[0];
+    const readOrder = fetchContactList.mock.invocationCallOrder[0];
+    expect(warmOrder).toBeLessThan(readOrder);
+  });
+
+  it("settles on none when relays have nothing — the commit guard is the backstop", async () => {
+    const { result } = renderHook(() => useVerifiedNoFollows(ME), { wrapper });
+
+    await waitFor(() => expect(result.current).toBe("none"));
+    expect(knownFollowCount(ME)).toBe(0);
+  });
+});

--- a/client/src/hooks/useVerifiedNoFollows.ts
+++ b/client/src/hooks/useVerifiedNoFollows.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchContactList } from "@/services/socialActions";
+import { fetchOutboxRelayList } from "@/services/nostr";
+import { knownFollowCount, recordFollowList } from "@/lib/followStore";
+import { identityHas } from "@/accounts/display";
+
+export type NoFollowsVerification = "checking" | "none" | "has-follows";
+
+/**
+ * "This user follows nobody" verified against relays, not just the cold local
+ * floor. The no-follows surfaces (dashboard picker card, home-page nudge,
+ * thread nudge) used to fire on `knownFollowCount` alone — 0 whenever the
+ * login-time fetch failed — so users with real follow lists were handed the
+ * new-user picker. This hook warms the outbox list (so the read hits their
+ * real write relays), fetches the kind-3 once per account, and repairs the
+ * floor via `recordFollowList` when a list is found (the floor only grows).
+ *
+ * Fast paths: a floor > 0 answers "has-follows" with no network; a key minted
+ * in this app answers "none" — it cannot have a prior list, and even if this
+ * is ever wrong the follow publish merges onto the relay base, so the worst
+ * case is a redundant picker, never a wipe.
+ *
+ * A fetch that finds nothing (or errors) settles on "none": hiding onboarding
+ * forever on a flaky network is worse than showing the picker, because the
+ * commit-time guard in `followPubkeys` is the backstop for the relays-down
+ * case.
+ */
+export function useVerifiedNoFollows(pubkey: string | null | undefined): NoFollowsVerification {
+  const floor = pubkey ? knownFollowCount(pubkey) : 0;
+  const mintedHere = !!pubkey && identityHas(pubkey, "createdInApp");
+  const needsCheck = !!pubkey && floor === 0 && !mintedHere;
+
+  const query = useQuery({
+    queryKey: ["verified-no-follows", pubkey],
+    enabled: needsCheck,
+    staleTime: 60_000,
+    retry: 1,
+    queryFn: async () => {
+      try { await fetchOutboxRelayList(pubkey!); } catch { /* best-effort warm */ }
+      const ev = await fetchContactList(pubkey!);
+      if (ev) {
+        recordFollowList(pubkey!, ev as any);
+        return "has-follows" as const;
+      }
+      return "none" as const;
+    },
+  });
+
+  if (!pubkey) return "checking";
+  if (floor > 0) return "has-follows";
+  if (mintedHere) return "none";
+  if (query.data) return query.data;
+  if (query.isError) return "none";
+  return "checking";
+}

--- a/client/src/lib/accountStorage.ts
+++ b/client/src/lib/accountStorage.ts
@@ -50,6 +50,7 @@ const NAMESPACES = {
   brainstorm_invite_cta_dismissed: "device",
   brainstorm_activate_seen: "device",
   brainstorm_nip85_dismissed_at: "device",
+  brainstorm_nip85_consent: "device",
   brainstorm_assistant: "device",
 } as const satisfies Record<string, Lifetime>;
 

--- a/client/src/lib/nip85Consent.test.ts
+++ b/client/src/lib/nip85Consent.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getNip85Consent, hasDeclinedNip85, hasNip85Consent, recordNip85Consent } from "./nip85Consent";
+import { accountKey } from "./accountStorage";
+
+const A = "a".repeat(64);
+const B = "b".repeat(64);
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("recording NIP-85 consent", () => {
+  it("round-trips a grant", () => {
+    recordNip85Consent(A, true);
+    expect(hasNip85Consent(A)).toBe(true);
+    expect(hasDeclinedNip85(A)).toBe(false);
+    expect(getNip85Consent(A)?.at).toBeGreaterThan(0);
+  });
+
+  it("round-trips a decline", () => {
+    recordNip85Consent(A, false);
+    expect(hasNip85Consent(A)).toBe(false);
+    expect(hasDeclinedNip85(A)).toBe(true);
+  });
+
+  // The dashboard CTA's cooldown is the one path that re-surfaces the ask after
+  // a decline, and it reads the dismissal timestamp — a decline must write it.
+  it("a decline also stamps the CTA dismissal", () => {
+    recordNip85Consent(A, false);
+    expect(Number(localStorage.getItem(accountKey("brainstorm_nip85_dismissed_at", A)))).toBeGreaterThan(0);
+  });
+
+  it("a grant does NOT stamp the CTA dismissal", () => {
+    recordNip85Consent(A, true);
+    expect(localStorage.getItem(accountKey("brainstorm_nip85_dismissed_at", A))).toBeNull();
+  });
+
+  it("answers per account — B is not asked to live with A's choice", () => {
+    recordNip85Consent(A, true);
+    expect(hasNip85Consent(B)).toBe(false);
+    expect(hasDeclinedNip85(B)).toBe(false);
+    expect(getNip85Consent(B)).toBeNull();
+  });
+
+  it("never asked reads as neither granted nor declined", () => {
+    expect(hasNip85Consent(A)).toBe(false);
+    expect(hasDeclinedNip85(A)).toBe(false);
+  });
+
+  it("tolerates a corrupt row", () => {
+    localStorage.setItem(accountKey("brainstorm_nip85_consent", A), "not-json");
+    expect(getNip85Consent(A)).toBeNull();
+    localStorage.setItem(accountKey("brainstorm_nip85_consent", A), JSON.stringify({ granted: "yes" }));
+    expect(getNip85Consent(A)).toBeNull();
+  });
+});

--- a/client/src/lib/nip85Consent.ts
+++ b/client/src/lib/nip85Consent.ts
@@ -1,0 +1,50 @@
+// Whether this Account said yes (or no) to publishing their NIP-85 kind-10040
+// at the "calculate my scores" step. This is device-local *intent*, recorded
+// before the publish happens — the published fact lives in `nip85Activation`
+// (account metadata) and relays. Keeping the two apart means a consent given on
+// a device that then failed to sign still drives the background retry, while a
+// decline suppresses every automatic publish path, createdInApp included.
+import { accountKey } from "@/lib/accountStorage";
+
+export interface Nip85Consent {
+  granted: boolean;
+  at: number;
+}
+
+export function recordNip85Consent(pubkey: string | null | undefined, granted: boolean): void {
+  if (!pubkey) return;
+  try {
+    localStorage.setItem(
+      accountKey("brainstorm_nip85_consent", pubkey),
+      JSON.stringify({ granted, at: Date.now() } satisfies Nip85Consent),
+    );
+  } catch { /* private browsing */ }
+  // A decline is also a dismissal: the dashboard CTA's cooldown is the one
+  // re-surface path, and it reads this timestamp.
+  if (!granted) {
+    try {
+      localStorage.setItem(accountKey("brainstorm_nip85_dismissed_at", pubkey), String(Date.now()));
+    } catch { /* private browsing */ }
+  }
+}
+
+export function getNip85Consent(pubkey?: string | null): Nip85Consent | null {
+  if (!pubkey) return null;
+  try {
+    const raw = localStorage.getItem(accountKey("brainstorm_nip85_consent", pubkey));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.granted !== "boolean") return null;
+    return { granted: parsed.granted, at: Number(parsed.at) || 0 };
+  } catch {
+    return null;
+  }
+}
+
+export function hasNip85Consent(pubkey?: string | null): boolean {
+  return getNip85Consent(pubkey)?.granted === true;
+}
+
+export function hasDeclinedNip85(pubkey?: string | null): boolean {
+  return getNip85Consent(pubkey)?.granted === false;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -113,7 +113,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { cacheProfile, fetchProfile, fetchOutboxRelayList, isUsingBrainstorm } from "@/services/nostr";
+import { cacheProfile, fetchProfile, fetchOutboxRelayList } from "@/services/nostr";
+import { useTrustProviderStatus } from "@/hooks/useTrustProviderStatus";
 import { logout } from "@/accounts/login-flow";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { DeferredSessionNotice } from "@/components/DeferredSession";
@@ -369,27 +370,23 @@ export default function DashboardPage() {
   const stats = statsQuery.data?.data ?? null;
 
   const taPubkey = history?.ta_pubkey;
-  const trustServiceProvider = useQuery({
-    queryKey: ["trustServiceProvider", user?.pubkey, taPubkey],
-    queryFn: async () => {
-      if (!user?.pubkey || !taPubkey) return false;
-      return await isUsingBrainstorm(user.pubkey, taPubkey);
-    },
-    enabled: !!user && !!taPubkey,
-    retry: 2,
-    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
-    staleTime: Infinity,
-  });
+  const trustServiceProvider = useTrustProviderStatus(user?.pubkey, taPubkey);
 
   useEffect(() => {
-    // Upgrade-only: a relay confirmation (isUsingBrainstorm === true) marks this
-    // account activated and shows the badge. A `false`/undefined is treated as
-    // "not propagated yet", NOT a deactivation — relays are eventually-consistent,
-    // so we never downgrade here (that caused the badge to flicker right after an
-    // auto-publish). Deactivation is explicit, via Settings.
-    if (trustServiceProvider.data !== true) return;
-    markNip85Activated(user?.pubkey);
-    if (!nip85Activated) setNip85Activated(true);
+    // The on-relay 10040 is the authority. "brainstorm" marks this account
+    // activated and shows the badge; "other" (a declaration naming a DIFFERENT
+    // assistant — definitive presence, not a miss) downgrades it, because a
+    // green "Active" badge over a foreign declaration is a lie. "none"/
+    // "unknown" are absence/silence and never downgrade — relays are
+    // eventually-consistent, and that flicker right after an auto-publish is
+    // what upgrade-only-on-miss protects against.
+    if (trustServiceProvider.data === "brainstorm") {
+      markNip85Activated(user?.pubkey);
+      if (!nip85Activated) setNip85Activated(true);
+    } else if (trustServiceProvider.data === "other") {
+      // The flag itself was cleared inside checkExistingTrustProvider.
+      if (nip85Activated) setNip85Activated(false);
+    }
   }, [trustServiceProvider.data, nip85Activated]);
 
   const grapeRankRaw = grapeRankQuery.data?.data;

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -119,6 +119,7 @@ import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { DeferredSessionNotice } from "@/components/DeferredSession";
 import { isNip85Activated, markNip85Activated } from "@/lib/nip85Activation";
 import { hasDeclinedNip85 } from "@/lib/nip85Consent";
+import { useVerifiedNoFollows } from "@/hooks/useVerifiedNoFollows";
 import { apiClient, isAuthRedirecting } from "@/services/api";
 import { TIER_LABELS } from "@/services/trustThreshold";
 import { useSelfOverview, useSelfHistory, useSelfStats } from "@/hooks/useSelf";
@@ -451,7 +452,14 @@ export default function DashboardPage() {
     ? typeof (grapeRank as any).ta_status === "string" && (grapeRank as any).ta_status.toLowerCase() === "failure"
     : false;
 
-  const hasNoFollowing = overviewQuery.isSuccess && followingCount === 0;
+  // The backend count alone lied here: it reads 0 until GrapeRank first ingests
+  // the contact list, so an existing user on a fresh device was handed the
+  // new-user follow picker. Only believe "no follows" once the relay-side
+  // verification agrees (it also repairs the local floor when a list is found,
+  // which lets AutoScoreReturning take over).
+  const followVerification = useVerifiedNoFollows(user?.pubkey);
+  const hasNoFollowing = overviewQuery.isSuccess && followingCount === 0 && followVerification === "none";
+  const followsChecking = overviewQuery.isSuccess && followingCount === 0 && followVerification === "checking";
 
   // The backend `following` count lags for brand-new accounts — it only fills in
   // after the first GrapeRank pass ingests the contact list. So a user who has
@@ -760,11 +768,14 @@ export default function DashboardPage() {
   // follows". For a brand-new account grapeRank resolves first, every other term
   // passes, and the onboarding panel flashed on screen for that window before
   // overview landed and yanked it away. Waiting for overview to settle closes it.
-  const showOnboarding = overviewQuery.isSuccess && !grapeRankQuery.isLoading && !publishDone && !hasNoFollowing && !isRecalculating && !hadPreviousScores;
+  // `followsChecking` closes the same flash for the relay verification window:
+  // while it's running, hasNoFollowing reads FALSE too, and without the guard
+  // the onboarding panel would show for a user about to get the follow picker.
+  const showOnboarding = overviewQuery.isSuccess && !grapeRankQuery.isLoading && !publishDone && !hasNoFollowing && !followsChecking && !isRecalculating && !hadPreviousScores;
   // No-follows is NOT an error — it's the "start here" state (handled by the
   // inline follow-picker). Only real GrapeRank/publish failures are errors, and
   // we suppress those right after a fresh follow+calculate.
-  const isErrorState = (isGrapeRankFailed || isPublishFailed) && !hasNoFollowing && !justFollowed;
+  const isErrorState = (isGrapeRankFailed || isPublishFailed) && !hasNoFollowing && !followsChecking && !justFollowed;
   // A "recalculation" requires PRIOR completed scores — not merely an in-progress
   // result object (which exists during a first-time calc too). Using `grapeRank`
   // here made a never-scored user's first calc read as "Refreshing / previous
@@ -1073,7 +1084,7 @@ export default function DashboardPage() {
             </AlertDialog>
 
             <AnimatePresence>
-              {(isGrapeRankFailed || isPublishFailed) && !hasNoFollowing && !justFollowed && !triggerGrapeRankMutation.isError && !triggerGrapeRankMutation.isPending && !triggerGrapeRankMutation.isSuccess && (
+              {(isGrapeRankFailed || isPublishFailed) && !hasNoFollowing && !followsChecking && !justFollowed && !triggerGrapeRankMutation.isError && !triggerGrapeRankMutation.isPending && !triggerGrapeRankMutation.isSuccess && (
                 <motion.div
                   initial={{ opacity: 0, y: -8, scale: 0.98 }}
                   animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -118,6 +118,7 @@ import { logout } from "@/accounts/login-flow";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { DeferredSessionNotice } from "@/components/DeferredSession";
 import { isNip85Activated, markNip85Activated } from "@/lib/nip85Activation";
+import { hasDeclinedNip85 } from "@/lib/nip85Consent";
 import { apiClient, isAuthRedirecting } from "@/services/api";
 import { TIER_LABELS } from "@/services/trustThreshold";
 import { useSelfOverview, useSelfHistory, useSelfStats } from "@/hooks/useSelf";
@@ -187,8 +188,10 @@ export default function DashboardPage() {
   const [wotExpanded, setWotExpanded] = useState(false);
   const [nip85Activated, setNip85Activated] = useState(() => isNip85Activated(user?.pubkey));
   const [nip85Dismissed, setNip85Dismissed] = useState(() => nip85DismissedRecently(user?.pubkey));
-  // In-app-created accounts auto-activate Brainstorm silently (see
-  // AutoActivateBrainstorm) — they never get the consent card.
+  // In-app-created accounts consent at the calculate step (or implicitly, for
+  // accounts that predate the consent card) and publish from there — the CTA
+  // card would only nag them. The exception is an explicit decline on that
+  // card: then this CTA is the one re-surface path, after the dismiss cooldown.
   const nip85CreatedInApp = (() => {
     return identityHas(user?.pubkey, "createdInApp");
   })();
@@ -1199,7 +1202,7 @@ export default function DashboardPage() {
             <TaggedYouModule />
           </div>
 
-          {publishDone && !isRecalculating && !nip85Activated && !nip85Dismissed && !nip85CreatedInApp && (
+          {publishDone && !isRecalculating && !nip85Activated && !nip85Dismissed && (!nip85CreatedInApp || hasDeclinedNip85(user?.pubkey)) && (
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}

--- a/client/src/pages/OnboardingWizard.test.tsx
+++ b/client/src/pages/OnboardingWizard.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 import { renderWithProviders } from "@/test/utils";
 import OnboardingWizard from "./OnboardingWizard";
@@ -18,8 +18,20 @@ vi.mock("@/hooks/useActiveAccountDisplay", () => ({
 vi.mock("@/services/nostr", () => ({
   publishProfile: vi.fn(async () => {}),
 }));
+const triggerScoringAndAnchor = vi.fn(async () => {});
 vi.mock("@/services/trustAnchor", () => ({
-  triggerScoringAndAnchor: vi.fn(async () => {}),
+  triggerScoringAndAnchor: (...args: unknown[]) => triggerScoringAndAnchor(...(args as [])),
+  publishBrainstormTrustAnchor: vi.fn(async () => ({ status: "success" })),
+  checkExistingTrustProvider: vi.fn(async () => "none"),
+}));
+// The wizard reads ta_pubkey through useSelfHistory; the real hook needs an
+// applesauce AccountsProvider these tests don't mount.
+vi.mock("@/hooks/useSelf", () => ({
+  useSelfHistory: () => ({ data: undefined, isSuccess: false }),
+}));
+// Real module drags in the account manager; the wizard only asks the flag.
+vi.mock("@/lib/nip85Activation", () => ({
+  isNip85Activated: () => false,
 }));
 vi.mock("@/services/socialActions", () => ({
   followPubkeys: vi.fn(async () => ({ success: true })),
@@ -84,5 +96,31 @@ describe("where the backup step sits", () => {
     fireEvent.click(screen.getByTestId("onboarding-backup-skip"));
 
     expect(navigate).toHaveBeenCalledWith("/", { replace: true });
+  });
+});
+
+describe("the NIP-85 ask on the follow step", () => {
+  it("consents by default — calculate carries {nip85Consent: true}", async () => {
+    renderWithProviders(<OnboardingWizard />);
+    fireEvent.click(screen.getByTestId("onboarding-profile-skip"));
+    expect(screen.getByTestId("nip85-consent-card")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("fake-follow-continue"));
+
+    await waitFor(() =>
+      expect(triggerScoringAndAnchor).toHaveBeenCalledWith(PUBKEY, { nip85Consent: true }),
+    );
+  });
+
+  it("an unchecked switch travels as {nip85Consent: false}", async () => {
+    renderWithProviders(<OnboardingWizard />);
+    fireEvent.click(screen.getByTestId("onboarding-profile-skip"));
+    fireEvent.click(screen.getByTestId("nip85-consent-toggle"));
+
+    fireEvent.click(screen.getByTestId("fake-follow-continue"));
+
+    await waitFor(() =>
+      expect(triggerScoringAndAnchor).toHaveBeenCalledWith(PUBKEY, { nip85Consent: false }),
+    );
   });
 });

--- a/client/src/pages/OnboardingWizard.tsx
+++ b/client/src/pages/OnboardingWizard.tsx
@@ -4,10 +4,13 @@ import { Loader2, ArrowRight } from "lucide-react";
 import { Wordmark } from "@/components/Wordmark";
 import { ImageUpload } from "@/components/ImageUpload";
 import { FollowPicker } from "@/components/FollowPicker";
+import { Nip85ConsentCard } from "@/components/Nip85ConsentCard";
 import { OnboardingBackupStep } from "@/components/OnboardingBackupStep";
 import { publishProfile } from "@/services/nostr";
-import { triggerScoringAndAnchor } from "@/services/trustAnchor";
+import { publishBrainstormTrustAnchor, triggerScoringAndAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
+import { useSelfHistory } from "@/hooks/useSelf";
+import { isNip85Activated } from "@/lib/nip85Activation";
 import { followPubkeys } from "@/services/socialActions";
 import { canBackUp } from "@/accounts/backup";
 import { DEFAULT_BANNER_CLASS, DEFAULT_BANNER_SRC, initialsFor } from "@/lib/profileDefaults";
@@ -79,6 +82,13 @@ export default function OnboardingWizard() {
   };
 
   // --- Follow step → publish kind-3 + trigger scoring in background, advance ---
+  // The NIP-85 ask lives beside the follow list; consent rides along with the
+  // calculate trigger, and when the backend has already minted the service key
+  // (it does so at first auth, independent of scoring) the kind-10040 publishes
+  // right here — a freshly created key signs silently, no waiting on scores.
+  const [nip85Consent, setNip85Consent] = useState(true);
+  const historyQuery = useSelfHistory(user?.pubkey);
+  const taPubkey = (historyQuery.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
   const followAndNext = (pks: string[]) => {
     if (!pks.length) return;
     if (user?.pubkey) { try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", user.pubkey), String(Date.now())); } catch {} }
@@ -90,7 +100,16 @@ export default function OnboardingWizard() {
           toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Try again from your dashboard." });
           return;
         }
-        if (user?.pubkey) await triggerScoringAndAnchor(user.pubkey);
+        if (!user?.pubkey) return;
+        await triggerScoringAndAnchor(user.pubkey, { nip85Consent });
+        if (nip85Consent && taPubkey && !isNip85Activated(user.pubkey)) {
+          // Cancelled/failed publishes stay quiet — the consent-gated background
+          // poll and app-load self-heal finish the job.
+          const published = await publishBrainstormTrustAnchor(user.pubkey, taPubkey);
+          if (published.status === "success") {
+            toast({ title: "Scores shared", description: "Other apps can now find your Brainstorm scores." });
+          }
+        }
       } catch { /* the status chip reflects the outcome */ }
     })();
     if (backupOffered) setStep("backup");
@@ -222,7 +241,16 @@ export default function OnboardingWizard() {
             <p className="mt-4 text-lg text-slate-600 dark:text-slate-300 leading-relaxed">
               Your network is built from who you follow. Pick at least one so Brainstorm can calculate your scores.
             </p>
-            <div className="mt-6">
+            {/* A key created here minutes ago can't have a 10040 — skip the relay pre-check. */}
+            <Nip85ConsentCard
+              pubkey={user?.pubkey}
+              taPubkey={taPubkey}
+              value={nip85Consent}
+              onChange={setNip85Consent}
+              skipProviderCheck
+              className="mt-5"
+            />
+            <div className="mt-4">
               <FollowPicker onContinue={followAndNext} continueLabel="Follow & continue" />
             </div>
           </div>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -74,6 +74,7 @@ import type { NostrEvent } from "applesauce-core/helpers";
 import { signNip85, signNip85Deactivation, publishToRelays, getNip85RelayUrl } from "@/services/nostr";
 import { logout } from "@/accounts/login-flow";
 import { isNip85Activated, markNip85Activated, clearNip85Activated } from "@/lib/nip85Activation";
+import { useTrustProviderStatus } from "@/hooks/useTrustProviderStatus";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { useBackupNeed } from "@/hooks/useBackupNeed";
 import { DeferredSessionNotice } from "@/components/DeferredSession";
@@ -227,8 +228,6 @@ export default function SettingsPage() {
     if (preset === activePreset || setPresetMutation.isPending) return;
     setPresetMutation.mutate(preset);
   }, [activePreset, setPresetMutation]);
-
-  const nip85Activated = isNip85Activated(user?.pubkey);
 
   useEffect(() => {
     if (!user) navigate("/", { replace: true });
@@ -384,6 +383,7 @@ export default function SettingsPage() {
 
     if (result.success) {
       markNip85Activated(user.pubkey);
+      queryClient.invalidateQueries({ queryKey: ["trust-provider-status"] });
       setRepublishState("success");
       toast({ title: "NIP-85 event updated", description: "Your service provider declaration has been re-published.", duration: 4000 });
       setTimeout(() => setRepublishState("idle"), 3000);
@@ -421,6 +421,7 @@ export default function SettingsPage() {
 
     if (result.success) {
       clearNip85Activated(user.pubkey);
+      queryClient.invalidateQueries({ queryKey: ["trust-provider-status"] });
       setDeactivateState("success");
       toast({ title: "Provider deactivated", description: "Brainstorm no longer publishes your scores for other apps to use.", duration: 4000 });
       setTimeout(() => {
@@ -449,6 +450,16 @@ export default function SettingsPage() {
   const taPubkey = historyData?.data?.ta_pubkey || null;
   const followingCount = overviewData?.data?.counts?.following ?? null;
   const hasNoFollowing = !selfLoading && followingCount === 0;
+
+  // "Status: Active / Provider: Brainstorm" must answer for the on-relay
+  // 10040, not the local flag alone — the flag never downgrades on a relay
+  // miss, so after the user activates a different provider elsewhere it would
+  // keep this card lying. A definitive foreign declaration ("other") reads as
+  // not activated; absence/silence keeps the flag's answer.
+  const trustProviderStatus = useTrustProviderStatus(user?.pubkey, taPubkey);
+  const nip85Activated =
+    trustProviderStatus.data === "brainstorm" ||
+    (trustProviderStatus.data !== "other" && isNip85Activated(user?.pubkey));
 
   if (!user || isAuthRedirecting()) return null;
 

--- a/client/src/pages/UserPanelPage.tsx
+++ b/client/src/pages/UserPanelPage.tsx
@@ -69,7 +69,8 @@ import {
 } from "lucide-react";
 import { AgentIcon } from "@/components/AgentIcon";
 import { ImageUpload } from "@/components/ImageUpload";
-import { fetchProfiles, isUsingBrainstorm, getNip85RelayUrl } from "@/services/nostr";
+import { fetchProfiles, getNip85RelayUrl } from "@/services/nostr";
+import { useTrustProviderStatus } from "@/hooks/useTrustProviderStatus";
 import { logout } from "@/accounts/login-flow";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { AdminBadge } from "@/components/AdminBadge";
@@ -288,18 +289,14 @@ export default function UserPanelPage() {
   });
 
   const taPubkey = historyData?.data?.ta_pubkey;
-  const trustServiceProvider = useQuery({
-    queryKey: ["trustServiceProvider", user?.pubkey, taPubkey],
-    queryFn: async () => {
-      if (!user?.pubkey || !taPubkey) return false;
-      return await isUsingBrainstorm(user.pubkey, taPubkey);
-    },
-    enabled: !!user && !!taPubkey,
-    retry: 2,
-    staleTime: Infinity,
-  });
+  const trustServiceProvider = useTrustProviderStatus(user?.pubkey, taPubkey);
 
-  const nip85Activated = trustServiceProvider.data === true || isNip85Activated(user?.pubkey);
+  // The on-relay 10040 wins: a declaration naming a different assistant reads
+  // as NOT activated no matter what the local flag says; absence/silence keeps
+  // the flag's answer (a relay miss is not a deactivation).
+  const nip85Activated =
+    trustServiceProvider.data === "brainstorm" ||
+    (trustServiceProvider.data !== "other" && isNip85Activated(user?.pubkey));
   const socialActions = useSocialActions(user?.pubkey);
 
   const followingList = useMemo(

--- a/client/src/pages/WelcomePage.tsx
+++ b/client/src/pages/WelcomePage.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "wouter";
 import { BrainLogo } from "@/components/BrainLogo";
+import { ConfirmNewFollowListDialog } from "@/components/ConfirmNewFollowListDialog";
 import { FollowPicker } from "@/components/FollowPicker";
 import { Nip85ConsentCard } from "@/components/Nip85ConsentCard";
 import { publishBrainstormTrustAnchor, triggerScoringAndAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { useSelfHistory } from "@/hooks/useSelf";
+import { useVerifiedNoFollows } from "@/hooks/useVerifiedNoFollows";
+import { identityHas } from "@/accounts/display";
 import { isNip85Activated } from "@/lib/nip85Activation";
-import { followPubkeys } from "@/services/socialActions";
+import { knownFollowCount } from "@/lib/followStore";
+import { followPubkeys, type FollowOptions } from "@/services/socialActions";
 import { useToast } from "@/hooks/use-toast";
 import { accountKey } from "@/lib/accountStorage";
 
@@ -44,23 +48,23 @@ export default function WelcomePage() {
   const historyQuery = useSelfHistory(user?.pubkey);
   const taPubkey = (historyQuery.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
 
-  // Navigate home IMMEDIATELY, then publish the follow list + trigger scoring in
-  // the background (the global ScoringStatusBar keeps the "calculating" state
-  // visible after this page unmounts). `followPubkeys` ingests the signed kind-3
-  // into the backend before returning, so scoring runs on fresh follows.
-  const finish = (pks: string[]) => {
-    if (!pks.length) return;
+  // Mount-time relay verification: repairs the local follow floor for imported
+  // keys (so the at-risk path below almost never engages) and warms the outbox
+  // list so the commit-time kind-3 read asks the user's real write relays.
+  useVerifiedNoFollows(user?.pubkey);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmPks, setConfirmPks] = useState<string[] | null>(null);
+
+  // Fire the toast + navigation + background scoring/NIP-85 chain — everything
+  // that happens after the kind-3 is (or is about to be) safely published.
+  const proceedHome = (publishFollows: null | (() => Promise<void>)) => {
     if (user?.pubkey) { try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", user.pubkey), String(Date.now())); } catch {} }
     toast({ title: "You're all set!", description: "Your trust network is calculating — explore and finish setting up in the meantime." });
     navigate(returnPath, { replace: true });
     void (async () => {
       try {
-        const res = await followPubkeys(pks);
-        if (res.cancelled) return;
-        if (!res.success) {
-          toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Try again from your dashboard." });
-          return;
-        }
+        if (publishFollows) await publishFollows();
         if (!user?.pubkey) return;
         await triggerScoringAndAnchor(user.pubkey, { nip85Consent });
         if (nip85Consent && taPubkey && !isNip85Activated(user.pubkey)) {
@@ -75,6 +79,51 @@ export default function WelcomePage() {
         /* the status chip + dashboard reflect the outcome */
       }
     })();
+  };
+
+  // At-risk cohort (imported key, no confirmed follows anywhere): the publish is
+  // AWAITED before navigating, because followPubkeys may come back asking for
+  // from-scratch confirmation and the user has to still be here to answer it.
+  const finishAtRisk = async (pks: string[], opts?: FollowOptions) => {
+    setSubmitting(true);
+    const res = await followPubkeys(pks, opts);
+    if (res.cancelled) {
+      setSubmitting(false);
+      return;
+    }
+    if (res.needsBaseConfirmation) {
+      setSubmitting(false);
+      setConfirmPks(pks);
+      return;
+    }
+    if (!res.success) {
+      setSubmitting(false);
+      toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Please try again." });
+      return;
+    }
+    proceedHome(null); // already published
+  };
+
+  // Everyone else navigates home IMMEDIATELY and publishes in the background
+  // (the global ScoringStatusBar keeps the "calculating" state visible after
+  // this page unmounts). `followPubkeys` ingests the signed kind-3 into the
+  // backend before returning, so scoring runs on fresh follows.
+  const finish = (pks: string[]) => {
+    if (!pks.length || submitting) return;
+    const pk = user?.pubkey;
+    const atRisk = !!pk && !identityHas(pk, "createdInApp") && knownFollowCount(pk) === 0;
+    if (atRisk) {
+      void finishAtRisk(pks);
+      return;
+    }
+    proceedHome(async () => {
+      const res = await followPubkeys(pks);
+      if (res.cancelled) throw new Error("cancelled");
+      if (!res.success) {
+        toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Try again from your dashboard." });
+        throw new Error(res.error || "follow publish failed");
+      }
+    });
   };
 
   return (
@@ -122,9 +171,20 @@ export default function WelcomePage() {
           className="mt-6"
         />
         <div className="mt-4">
-          <FollowPicker onContinue={finish} continueLabel="Follow & calculate my scores" />
+          <FollowPicker onContinue={finish} continueLabel="Follow & calculate my scores" busy={submitting} />
         </div>
       </main>
+
+      <ConfirmNewFollowListDialog
+        open={confirmPks !== null}
+        busy={submitting}
+        onCancel={() => setConfirmPks(null)}
+        onConfirm={() => {
+          const pks = confirmPks;
+          setConfirmPks(null);
+          if (pks) void finishAtRisk(pks, { allowFromScratch: true });
+        }}
+      />
     </div>
   );
 }

--- a/client/src/pages/WelcomePage.tsx
+++ b/client/src/pages/WelcomePage.tsx
@@ -1,9 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "wouter";
 import { BrainLogo } from "@/components/BrainLogo";
 import { FollowPicker } from "@/components/FollowPicker";
-import { triggerScoringAndAnchor } from "@/services/trustAnchor";
+import { Nip85ConsentCard } from "@/components/Nip85ConsentCard";
+import { publishBrainstormTrustAnchor, triggerScoringAndAnchor } from "@/services/trustAnchor";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
+import { useSelfHistory } from "@/hooks/useSelf";
+import { isNip85Activated } from "@/lib/nip85Activation";
 import { followPubkeys } from "@/services/socialActions";
 import { useToast } from "@/hooks/use-toast";
 import { accountKey } from "@/lib/accountStorage";
@@ -33,6 +36,14 @@ export default function WelcomePage() {
     return "/";
   })();
 
+  // The NIP-85 ask sits beside the follow list. Their service key already
+  // exists (minted at first auth, independent of scoring), so with consent the
+  // kind-10040 is signed right after the kind-3 — the signer is already warm —
+  // instead of a background prompt minutes later.
+  const [nip85Consent, setNip85Consent] = useState(true);
+  const historyQuery = useSelfHistory(user?.pubkey);
+  const taPubkey = (historyQuery.data as { data?: { ta_pubkey?: string | null } } | undefined)?.data?.ta_pubkey;
+
   // Navigate home IMMEDIATELY, then publish the follow list + trigger scoring in
   // the background (the global ScoringStatusBar keeps the "calculating" state
   // visible after this page unmounts). `followPubkeys` ingests the signed kind-3
@@ -50,7 +61,16 @@ export default function WelcomePage() {
           toast({ variant: "destructive", title: "Couldn't save your follows", description: res.error || "Try again from your dashboard." });
           return;
         }
-        if (user?.pubkey) await triggerScoringAndAnchor(user.pubkey);
+        if (!user?.pubkey) return;
+        await triggerScoringAndAnchor(user.pubkey, { nip85Consent });
+        if (nip85Consent && taPubkey && !isNip85Activated(user.pubkey)) {
+          // Cancelled/failed publishes stay quiet — the consent-gated background
+          // poll and app-load self-heal finish the job.
+          const published = await publishBrainstormTrustAnchor(user.pubkey, taPubkey);
+          if (published.status === "success") {
+            toast({ title: "Scores shared", description: "Other apps can now find your Brainstorm scores." });
+          }
+        }
       } catch {
         /* the status chip + dashboard reflect the outcome */
       }
@@ -94,7 +114,14 @@ export default function WelcomePage() {
           calculate your scores and personalize your results.
         </p>
 
-        <div className="mt-6">
+        <Nip85ConsentCard
+          pubkey={user?.pubkey}
+          taPubkey={taPubkey}
+          value={nip85Consent}
+          onChange={setNip85Consent}
+          className="mt-6"
+        />
+        <div className="mt-4">
           <FollowPicker onContinue={finish} continueLabel="Follow & calculate my scores" />
         </div>
       </main>

--- a/client/src/services/socialActions.test.ts
+++ b/client/src/services/socialActions.test.ts
@@ -91,6 +91,9 @@ beforeEach(async () => {
   activeAccount.mockReturnValue({ pubkey: ME });
   publishToRelays.mockResolvedValue({ success: true });
   createdInApp.mockReturnValue(false);
+  // clearAllMocks keeps implementations — restore the inert default so a
+  // test's relay-seeding warm can't leak into its neighbours.
+  fetchOutboxRelayList.mockImplementation(async () => undefined);
   social = await import("./socialActions");
 });
 
@@ -226,7 +229,7 @@ describe("creating a first follow list", () => {
   it("warms the outbox list and retries before giving up", async () => {
     // The first fetch (hardcoded profile relays) finds nothing; the warm makes
     // the user's real write relays reachable, and the retry finds the list.
-    fetchOutboxRelayList.mockImplementation(async () => {
+    fetchOutboxRelayList.mockImplementationOnce(async () => {
       relayHas.set(3, [listEvent(3, [OTHER])]);
       return undefined;
     });

--- a/client/src/services/socialActions.test.ts
+++ b/client/src/services/socialActions.test.ts
@@ -21,10 +21,19 @@ const activeAccount = vi.fn();
 const submitFollowList = vi.fn(async () => undefined);
 /** What the relays answer with, per kind. */
 const relayHas = new Map<number, unknown[]>();
+/** The outbox warm — tests make it "reveal" the real list by seeding relayHas. */
+const fetchOutboxRelayList = vi.fn(async () => undefined as unknown);
+/** Whether the active key was minted in this app (createdInApp). */
+const createdInApp = vi.fn(() => false);
 
 vi.mock("./nostr", () => ({
   publishToRelays: (...args: unknown[]) => publishToRelays(...(args as [])),
   loadOutboxRelayListFromDb: () => ["wss://one"],
+  fetchOutboxRelayList: (...args: unknown[]) => fetchOutboxRelayList(...(args as [])),
+}));
+
+vi.mock("@/accounts/display", () => ({
+  identityHas: () => createdInApp(),
 }));
 
 // The relay reads go through `lib/relayRequest` now, which reaches the pool
@@ -81,6 +90,7 @@ beforeEach(async () => {
   relayHas.clear();
   activeAccount.mockReturnValue({ pubkey: ME });
   publishToRelays.mockResolvedValue({ success: true });
+  createdInApp.mockReturnValue(false);
   social = await import("./socialActions");
 });
 
@@ -108,7 +118,11 @@ describe("following", () => {
     expect(signAs).not.toHaveBeenCalled();
   });
 
-  it("publishes an empty list for a genuinely new account", async () => {
+  // From-scratch without friction is reserved for keys minted in this app — the
+  // only case where "no list exists anywhere" is a fact rather than a guess.
+  it("publishes an empty list for an account created in this app", async () => {
+    createdInApp.mockReturnValue(true);
+
     const res = await social.followUser(THEM, null);
 
     expect(res.success).toBe(true);
@@ -190,6 +204,81 @@ describe("unfollowing", () => {
     const res = await social.unfollowUser(THEM, null);
 
     expect(res.success).toBe(false);
+    expect(signAs).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The from-scratch guard. A missing base for an imported key is ambiguous —
+ * "no list exists" and "no relay answered" look identical — and publishing a
+ * fresh kind-3 on a guess is how a real list gets replaced. Only a key minted
+ * in this app, or an explicit user confirmation, may create a first list.
+ */
+describe("creating a first follow list", () => {
+  it("refuses for an imported key when nothing was found anywhere", async () => {
+    const res = await social.followPubkeys([THEM]);
+
+    expect(res.success).toBe(false);
+    expect(res.needsBaseConfirmation).toBe(true);
+    expect(signAs).not.toHaveBeenCalled();
+  });
+
+  it("warms the outbox list and retries before giving up", async () => {
+    // The first fetch (hardcoded profile relays) finds nothing; the warm makes
+    // the user's real write relays reachable, and the retry finds the list.
+    fetchOutboxRelayList.mockImplementation(async () => {
+      relayHas.set(3, [listEvent(3, [OTHER])]);
+      return undefined;
+    });
+
+    const res = await social.followPubkeys([THEM]);
+
+    expect(fetchOutboxRelayList).toHaveBeenCalledTimes(1);
+    expect(res.success).toBe(true);
+    expect(signedPubkeys()).toEqual([OTHER, THEM]); // merged, not from scratch
+  });
+
+  it("creates the list once the user has explicitly confirmed", async () => {
+    const res = await social.followPubkeys([THEM], { allowFromScratch: true });
+
+    expect(res.success).toBe(true);
+    expect(signedPubkeys()).toEqual([THEM]);
+  });
+
+  it("never asks a key created in this app for confirmation", async () => {
+    createdInApp.mockReturnValue(true);
+
+    const res = await social.followPubkeys([THEM]);
+
+    expect(res.success).toBe(true);
+    expect(res.needsBaseConfirmation).toBeUndefined();
+    expect(fetchOutboxRelayList).not.toHaveBeenCalled();
+    expect(signedPubkeys()).toEqual([THEM]);
+  });
+
+  it("applies the same guard to a single follow", async () => {
+    const refused = await social.followUser(THEM, null);
+    expect(refused.success).toBe(false);
+    expect(refused.needsBaseConfirmation).toBe(true);
+    expect(signAs).not.toHaveBeenCalled();
+
+    const confirmed = await social.followUser(THEM, null, { allowFromScratch: true });
+    expect(confirmed.success).toBe(true);
+    expect(signedPubkeys()).toEqual([THEM]);
+  });
+
+  it("a known floor still beats everything — refusal, not a dialog", async () => {
+    // The store has a count but no usable event (corrupt row): unsafe wins and
+    // the outcome is a retryable failure, never a from-scratch confirmation.
+    localStorage.setItem(
+      `brainstorm_known_follows:${ME}`,
+      JSON.stringify({ event: { tags: [["p", OTHER]] }, count: 5, updated_at: 1 }),
+    );
+
+    const res = await social.followPubkeys([THEM]);
+
+    expect(res.success).toBe(false);
+    expect(res.needsBaseConfirmation).toBeUndefined();
     expect(signAs).not.toHaveBeenCalled();
   });
 });

--- a/client/src/services/socialActions.ts
+++ b/client/src/services/socialActions.ts
@@ -1,9 +1,10 @@
 import { ContactsFactory } from "applesauce-common/factories";
 import { MuteListFactory } from "applesauce-common/factories";
 
-import { publishToRelays, loadOutboxRelayListFromDb } from "./nostr";
+import { publishToRelays, loadOutboxRelayListFromDb, fetchOutboxRelayList } from "./nostr";
 import { requestAll, requestNewest } from "@/lib/relayRequest";
 import { PROFILE_RELAYS } from "@/lib/relays";
+import { identityHas } from "@/accounts/display";
 import { activeAccount, signAs, signingFailure, type PublishOutcome } from "@/accounts/signing";
 import type { BrainstormAccount } from "@/accounts/metadata";
 import { apiClient } from "./api";
@@ -109,23 +110,61 @@ export function getMutedPubkeys(muteList: NostrEvent | null): Set<string> {
  * snapshot}. Returns `{ base: null }` when we can't confirm a base AND the user
  * is known to follow people — the caller MUST abort rather than publish, or it
  * would wipe the list.
+ *
+ * `unverifiedNew` is the residual hole `unsafe` can't see: nothing found
+ * anywhere AND the floor is 0 AND the key was NOT minted in this app. That is
+ * either a genuinely-new key or an existing user whose list we simply failed to
+ * reach (fresh device, relays down, kind-10002 not loaded) — and the two are
+ * indistinguishable from here, because a relay timeout and "no kind-3 exists"
+ * both come back empty. Before concluding, we warm the outbox list (ingests the
+ * kind-10002 into the eventStore, so the retry asks the user's REAL write
+ * relays, not just the hardcoded PROFILE_RELAYS) and look once more. Still
+ * nothing → the caller must NOT publish from scratch without explicit user
+ * confirmation: a from-scratch kind-3 carries a newer created_at and would
+ * replace whatever list actually exists.
  */
 async function resolveContactBase(
   pubkey: string,
   cached?: NostrEvent | null,
-): Promise<{ base: NostrEvent | null; known: number; unsafe: boolean }> {
+): Promise<{ base: NostrEvent | null; known: number; unsafe: boolean; unverifiedNew: boolean }> {
   const known = knownFollowCount(pubkey);
   const fresh = cached ?? (await fetchContactList(pubkey));
   const stored = loadKnownFollowList(pubkey)?.event as NostrEvent | undefined;
-  const base = pickAuthoritativeBase([cached, fresh, stored]);
+  let base = pickAuthoritativeBase([cached, fresh, stored]);
+  const mintedHere = identityHas(pubkey, "createdInApp");
+  if (!base && !mintedHere) {
+    try { await fetchOutboxRelayList(pubkey); } catch { /* best-effort warm */ }
+    base = pickAuthoritativeBase([await fetchContactList(pubkey), stored]);
+  }
   // Unsafe = we have no usable base, or the best base is shorter than what we
   // know the user follows (a stale/short relay read). Either way, don't publish.
   const baseCount = base ? countFollows(base.tags) : 0;
   const unsafe = (!base && known > 0) || (known > 0 && baseCount < known);
-  return { base, known, unsafe };
+  const unverifiedNew = !base && known === 0 && !mintedHere;
+  return { base, known, unsafe, unverifiedNew };
 }
 
 const NOT_LOGGED_IN: PublishOutcome = { success: false, error: "Not logged in" };
+
+/**
+ * A follow publish can fail one way no other publish can: we couldn't confirm
+ * whether this key already has a follow list somewhere. `needsBaseConfirmation`
+ * means nothing was published and the caller must either retry later or ask the
+ * user the one question only they can answer — "have you ever followed anyone
+ * with this key?" — and re-call with `allowFromScratch: true`.
+ */
+export type FollowOutcome = PublishOutcome & { needsBaseConfirmation?: boolean };
+
+export interface FollowOptions {
+  /** The user explicitly confirmed this key has no prior follow list. */
+  allowFromScratch?: boolean;
+}
+
+const UNCONFIRMED_BASE: FollowOutcome = {
+  success: false,
+  needsBaseConfirmation: true,
+  error: "We couldn't confirm an existing follow list for this key — try again in a moment.",
+};
 
 /** A `p` tag naming this pubkey — how every follow and mute list is indexed. */
 const isPTagFor = (pubkey: string) => (tag: string[]) => tag[0] === "p" && tag[1] === pubkey;
@@ -159,6 +198,9 @@ async function publishContactList(
       // the caller's subsequent GrapeRank trigger scores fresh follows (not stale
       // relay-propagation state). Best-effort — never fails the follow.
       await ingestFollowList(signed);
+      // "Accepted" is a relay's OK frame, not proof our event is now the newest
+      // kind-3 out there. Verify in the background and warn if it isn't.
+      void verifyPublishedContactList(signed as unknown as NostrEvent);
     }
     return res;
   } catch (e) {
@@ -166,17 +208,47 @@ async function publishContactList(
   }
 }
 
-export async function followUser(targetPubkey: string, cachedContactList?: NostrEvent | null): Promise<PublishOutcome> {
+/**
+ * Post-publish check that our kind-3 actually became the user's newest contact
+ * list on their write relays. If the newest event out there is someone else's
+ * (a race with another client) or ours vanished AND what's there is shorter
+ * than what we published, the follows the user just made may not stick — say
+ * so instead of leaving them to find out weeks later. Never throws; the floor
+ * is NOT touched here (recordFollowList already stored our own signed event).
+ */
+async function verifyPublishedContactList(published: NostrEvent): Promise<void> {
+  try {
+    // Give propagation a beat; an instant read mostly measures relay latency.
+    await new Promise((r) => setTimeout(r, 3000));
+    const newest = await fetchContactList(published.pubkey);
+    if (!newest) return; // relays quiet — nothing to conclude
+    if (newest.id && published.id && newest.id === published.id) return; // landed
+    if (countFollows(newest.tags) >= countFollows(published.tags)) return; // superseded by a longer list — fine
+    const { toast } = await import("@/hooks/use-toast");
+    toast({
+      variant: "destructive",
+      title: "Your follow list may not have saved",
+      description: "A relay is still serving an older list. Check your follows in a moment and retry if anything is missing.",
+    });
+  } catch { /* best-effort */ }
+}
+
+export async function followUser(
+  targetPubkey: string,
+  cachedContactList?: NostrEvent | null,
+  opts: FollowOptions = {},
+): Promise<FollowOutcome> {
   const account = activeAccount();
   if (!account) return NOT_LOGGED_IN;
   if (account.pubkey === targetPubkey) return { success: false, error: "Cannot follow yourself" };
 
-  const { base, unsafe } = await resolveContactBase(account.pubkey, cachedContactList);
+  const { base, unsafe, unverifiedNew } = await resolveContactBase(account.pubkey, cachedContactList);
   if (unsafe) {
     return { success: false, error: "Couldn't load your full follow list — try again in a moment." };
   }
+  if (unverifiedNew && !opts.allowFromScratch) return UNCONFIRMED_BASE;
   if (base) recordFollowList(account.pubkey, base as any); // remember the largest seen
-  const baseTags = base?.tags ?? []; // brand-new account: genuinely empty list
+  const baseTags = base?.tags ?? []; // confirmed new key (or user-confirmed): genuinely empty list
 
   if (baseTags.some(isPTagFor(targetPubkey))) return { success: true };
 
@@ -204,16 +276,20 @@ export async function unfollowUser(targetPubkey: string, cachedContactList?: Nos
  * authoritative base (empty for a brand-new account) and never shrinks an
  * existing list.
  */
-export async function followPubkeys(targetPubkeys: string[]): Promise<PublishOutcome> {
+export async function followPubkeys(
+  targetPubkeys: string[],
+  opts: FollowOptions = {},
+): Promise<FollowOutcome> {
   const account = activeAccount();
   if (!account) return NOT_LOGGED_IN;
   const wanted = targetPubkeys.filter((pk) => /^[0-9a-f]{64}$/i.test(pk) && pk !== account.pubkey);
   if (!wanted.length) return { success: false, error: "No valid accounts to follow" };
 
-  const { base, unsafe } = await resolveContactBase(account.pubkey);
+  const { base, unsafe, unverifiedNew } = await resolveContactBase(account.pubkey);
   if (unsafe) {
     return { success: false, error: "Couldn't load your full follow list — try again in a moment." };
   }
+  if (unverifiedNew && !opts.allowFromScratch) return UNCONFIRMED_BASE;
   if (base) recordFollowList(account.pubkey, base as any);
   const baseTags = base?.tags ?? [];
   const have = new Set(baseTags.filter((t) => t[0] === "p").map((t) => t[1]));

--- a/client/src/services/trustAnchor.test.ts
+++ b/client/src/services/trustAnchor.test.ts
@@ -17,6 +17,9 @@ const isUnlockCancelled = vi.fn(() => false);
 const identityHas = vi.fn(() => false);
 const isNip85Activated = vi.fn(() => false);
 const markNip85Activated = vi.fn();
+const clearNip85Activated = vi.fn();
+const activeAccount = vi.fn((): { pubkey: string } | null => null);
+const canSignSilently = vi.fn(async () => false);
 
 vi.mock("./api", () => ({
   apiClient: {
@@ -33,8 +36,8 @@ vi.mock("./nostr", () => ({
   signNip85: (...a: unknown[]) => signNip85(...(a as [])),
 }));
 vi.mock("@/accounts/signing", () => ({
-  activeAccount: () => null,
-  canSignSilently: async () => false,
+  activeAccount: () => activeAccount(),
+  canSignSilently: () => canSignSilently(),
 }));
 vi.mock("@/accounts/local-signer", () => ({
   isUnlockCancelled: (e: unknown) => isUnlockCancelled(e),
@@ -45,10 +48,12 @@ vi.mock("@/accounts/display", () => ({
 vi.mock("@/lib/nip85Activation", () => ({
   isNip85Activated: (...a: unknown[]) => isNip85Activated(...(a as [])),
   markNip85Activated: (...a: unknown[]) => markNip85Activated(...(a as [])),
+  clearNip85Activated: (...a: unknown[]) => clearNip85Activated(...(a as [])),
 }));
 
 import {
   checkExistingTrustProvider,
+  ensureBrainstormTrustAnchor,
   publishBrainstormTrustAnchor,
   shouldAutoPublishNip85,
   triggerScoringAndAnchor,
@@ -154,10 +159,13 @@ describe("checkExistingTrustProvider — the consent card's pre-check", () => {
     expect(markNip85Activated).toHaveBeenCalledWith(ME);
   });
 
-  it("a declaration naming someone else → other", async () => {
+  it("a declaration naming someone else → other, and the local flag is dropped", async () => {
     fetchTrustProviderList.mockResolvedValueOnce({ tags: [["30382:rank", "c".repeat(64), "wss://elsewhere"]] });
     expect(await checkExistingTrustProvider(ME, TA)).toBe("other");
     expect(markNip85Activated).not.toHaveBeenCalled();
+    // A foreign declaration is definitive presence — the "activated" cache must
+    // not keep claiming Brainstorm over it.
+    expect(clearNip85Activated).toHaveBeenCalledWith(ME);
   });
 
   // Any 10040 is not enough — assistants are per-user keys, so even a
@@ -168,6 +176,9 @@ describe("checkExistingTrustProvider — the consent card's pre-check", () => {
     fetchTrustProviderList.mockResolvedValue({ tags: [["30382:rank", "c".repeat(64), "wss://nip85.example"]] });
     expect(await checkExistingTrustProvider(ME)).toBe("other");
     expect(markNip85Activated).not.toHaveBeenCalled();
+    // …but with no assistant key to compare against, "other" is a guess, not
+    // evidence — the flag must survive it.
+    expect(clearNip85Activated).not.toHaveBeenCalled();
   });
 
   it("rank pubkey equal to the assistant counts even when the strict relay check fails", async () => {
@@ -175,5 +186,50 @@ describe("checkExistingTrustProvider — the consent card's pre-check", () => {
     expect(await checkExistingTrustProvider(ME, TA)).toBe("brainstorm");
     // …but only the strict both-tags+relay match is recorded as published fact.
     expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The automatic publish path (background poll + app-load self-heal) versus a
+ * foreign declaration. `isUsingBrainstorm === false` alone cannot tell "no
+ * 10040" from "a 10040 naming someone else" — and only the second must stop
+ * the publish: the user's on-relay declaration takes precedence over anything
+ * this app decided in the background.
+ */
+describe("ensureBrainstormTrustAnchor — the on-relay 10040 wins", () => {
+  beforeEach(() => {
+    isNip85Activated.mockReturnValue(false);
+    activeAccount.mockReturnValue({ pubkey: ME });
+    canSignSilently.mockResolvedValue(true);
+    // clearAllMocks keeps implementations — pin the inert defaults so a
+    // persistent mockResolvedValue can't leak between these tests.
+    fetchTrustProviderList.mockResolvedValue(undefined);
+    isUsingBrainstorm.mockResolvedValue(false);
+  });
+
+  it("backs off from a declaration naming a different assistant — never a silent replace", async () => {
+    fetchTrustProviderList.mockResolvedValue({ tags: [["30382:rank", "c".repeat(64), "wss://elsewhere"]] });
+
+    await ensureBrainstormTrustAnchor(ME, TA);
+
+    expect(signNip85).not.toHaveBeenCalled();
+    expect(publishToRelays).not.toHaveBeenCalled();
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+
+  it("records an existing Brainstorm declaration and stops", async () => {
+    isUsingBrainstorm.mockResolvedValueOnce(true);
+
+    await ensureBrainstormTrustAnchor(ME, TA);
+
+    expect(markNip85Activated).toHaveBeenCalledWith(ME);
+    expect(signNip85).not.toHaveBeenCalled();
+  });
+
+  it("publishes when relays hold no declaration at all", async () => {
+    await ensureBrainstormTrustAnchor(ME, TA);
+
+    expect(signNip85).toHaveBeenCalledWith(TA, "wss://nip85.example");
+    expect(markNip85Activated).toHaveBeenCalledWith(ME);
   });
 });

--- a/client/src/services/trustAnchor.test.ts
+++ b/client/src/services/trustAnchor.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The consent gate and the user-initiated NIP-85 publish, introduced when the
+ * 10040 ask moved to the calculate step. The stakes: `shouldAutoPublishNip85`
+ * decides whether we ever sign under the user's key without them clicking a
+ * publish button, so an explicit decline must beat every implicit yes.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const triggerGrapeRank = vi.fn(async () => ({}));
+const getUserHistory = vi.fn(async () => ({ data: {} }));
+const signNip85 = vi.fn(async () => ({ id: "e".repeat(64), pubkey: "a".repeat(64) }));
+const publishToRelays = vi.fn(async () => ({ success: true }));
+const isUsingBrainstorm = vi.fn(async () => false);
+const fetchTrustProviderList = vi.fn(async (): Promise<{ tags: string[][] } | undefined> => undefined);
+const fetchOutboxRelayList = vi.fn(async () => undefined);
+const isUnlockCancelled = vi.fn(() => false);
+const identityHas = vi.fn(() => false);
+const isNip85Activated = vi.fn(() => false);
+const markNip85Activated = vi.fn();
+
+vi.mock("./api", () => ({
+  apiClient: {
+    triggerGrapeRank: () => triggerGrapeRank(),
+    getUserHistory: () => getUserHistory(),
+  },
+}));
+vi.mock("./nostr", () => ({
+  fetchOutboxRelayList: (...a: unknown[]) => fetchOutboxRelayList(...(a as [])),
+  fetchTrustProviderList: (...a: unknown[]) => fetchTrustProviderList(...(a as [])),
+  getNip85RelayUrl: () => "wss://nip85.example",
+  isUsingBrainstorm: (...a: unknown[]) => isUsingBrainstorm(...(a as [])),
+  publishToRelays: (...a: unknown[]) => publishToRelays(...(a as [])),
+  signNip85: (...a: unknown[]) => signNip85(...(a as [])),
+}));
+vi.mock("@/accounts/signing", () => ({
+  activeAccount: () => null,
+  canSignSilently: async () => false,
+}));
+vi.mock("@/accounts/local-signer", () => ({
+  isUnlockCancelled: (e: unknown) => isUnlockCancelled(e),
+}));
+vi.mock("@/accounts/display", () => ({
+  identityHas: (...a: unknown[]) => identityHas(...(a as [])),
+}));
+vi.mock("@/lib/nip85Activation", () => ({
+  isNip85Activated: (...a: unknown[]) => isNip85Activated(...(a as [])),
+  markNip85Activated: (...a: unknown[]) => markNip85Activated(...(a as [])),
+}));
+
+import {
+  checkExistingTrustProvider,
+  publishBrainstormTrustAnchor,
+  shouldAutoPublishNip85,
+  triggerScoringAndAnchor,
+} from "./trustAnchor";
+import { hasNip85Consent, recordNip85Consent } from "@/lib/nip85Consent";
+
+const ME = "a".repeat(64);
+const TA = "f".repeat(64);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  identityHas.mockReturnValue(false);
+  // Keeps `pollAndPublishTrustAnchor` a no-op so consenting trigger tests don't
+  // leave a 15-second timer running behind the assertions.
+  isNip85Activated.mockReturnValue(true);
+});
+
+describe("shouldAutoPublishNip85 — who may be published for without a click", () => {
+  it("explicit consent enables it for any account type", () => {
+    recordNip85Consent(ME, true);
+    expect(shouldAutoPublishNip85(ME)).toBe(true);
+  });
+
+  it("never-asked + created in app keeps the legacy implicit consent", () => {
+    identityHas.mockReturnValue(true);
+    expect(shouldAutoPublishNip85(ME)).toBe(true);
+  });
+
+  it("an explicit decline beats createdInApp", () => {
+    identityHas.mockReturnValue(true);
+    recordNip85Consent(ME, false);
+    expect(shouldAutoPublishNip85(ME)).toBe(false);
+  });
+
+  it("never-asked + external key stays manual-only", () => {
+    expect(shouldAutoPublishNip85(ME)).toBe(false);
+  });
+});
+
+describe("triggerScoringAndAnchor", () => {
+  it("records the consent it was handed, then triggers scoring", async () => {
+    await triggerScoringAndAnchor(ME, { nip85Consent: true });
+    expect(hasNip85Consent(ME)).toBe(true);
+    expect(triggerGrapeRank).toHaveBeenCalledTimes(1);
+  });
+
+  it("records a decline the same way", async () => {
+    await triggerScoringAndAnchor(ME, { nip85Consent: false });
+    expect(hasNip85Consent(ME)).toBe(false);
+    expect(triggerGrapeRank).toHaveBeenCalledTimes(1);
+  });
+
+  it("legacy callers (no opts) leave the consent record untouched", async () => {
+    await triggerScoringAndAnchor(ME);
+    expect(localStorage.getItem(`brainstorm_nip85_consent:${ME}`)).toBeNull();
+    expect(triggerGrapeRank).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("publishBrainstormTrustAnchor — the user-initiated publish", () => {
+  it("signs, publishes, marks activated, and narrates its phases", async () => {
+    const phases: string[] = [];
+    const res = await publishBrainstormTrustAnchor(ME, TA, (p) => phases.push(p));
+    expect(res).toEqual({ status: "success" });
+    expect(signNip85).toHaveBeenCalledWith(TA, "wss://nip85.example");
+    expect(markNip85Activated).toHaveBeenCalledWith(ME);
+    expect(phases).toEqual(["signing", "publishing"]);
+  });
+
+  it("a refused signature is cancelled, not an error", async () => {
+    signNip85.mockRejectedValueOnce(new Error("nope"));
+    const res = await publishBrainstormTrustAnchor(ME, TA);
+    expect(res).toEqual({ status: "cancelled", unlockDeclined: false });
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+
+  it("a declined unlock is flagged so callers can stay silent", async () => {
+    signNip85.mockRejectedValueOnce(new Error("locked"));
+    isUnlockCancelled.mockReturnValueOnce(true);
+    const res = await publishBrainstormTrustAnchor(ME, TA);
+    expect(res).toEqual({ status: "cancelled", unlockDeclined: true });
+  });
+
+  it("relay rejection surfaces the message and does not mark activated", async () => {
+    publishToRelays.mockResolvedValueOnce({ success: false, error: "all relays refused" } as never);
+    const res = await publishBrainstormTrustAnchor(ME, TA);
+    expect(res).toEqual({ status: "error", message: "all relays refused" });
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkExistingTrustProvider — the consent card's pre-check", () => {
+  it("no 10040 on their outbox relays → none", async () => {
+    expect(await checkExistingTrustProvider(ME, TA)).toBe("none");
+    // The outbox list is warmed first so the 10040 read routes correctly.
+    expect(fetchOutboxRelayList).toHaveBeenCalledWith(ME);
+  });
+
+  it("an exact Brainstorm declaration → brainstorm, recorded locally", async () => {
+    isUsingBrainstorm.mockResolvedValueOnce(true);
+    expect(await checkExistingTrustProvider(ME, TA)).toBe("brainstorm");
+    expect(markNip85Activated).toHaveBeenCalledWith(ME);
+  });
+
+  it("a declaration naming someone else → other", async () => {
+    fetchTrustProviderList.mockResolvedValueOnce({ tags: [["30382:rank", "c".repeat(64), "wss://elsewhere"]] });
+    expect(await checkExistingTrustProvider(ME, TA)).toBe("other");
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+
+  // Any 10040 is not enough — assistants are per-user keys, so even a
+  // Brainstorm-relay-hinted declaration counts only when its rank pubkey IS
+  // this user's assistant. Unverifiable (no ta_pubkey yet) reads as "other";
+  // the card re-checks once /user/history delivers the key.
+  it("without a ta_pubkey, an existing declaration is never 'already set'", async () => {
+    fetchTrustProviderList.mockResolvedValue({ tags: [["30382:rank", "c".repeat(64), "wss://nip85.example"]] });
+    expect(await checkExistingTrustProvider(ME)).toBe("other");
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+
+  it("rank pubkey equal to the assistant counts even when the strict relay check fails", async () => {
+    fetchTrustProviderList.mockResolvedValueOnce({ tags: [["30382:rank", TA, "wss://elsewhere"]] });
+    expect(await checkExistingTrustProvider(ME, TA)).toBe("brainstorm");
+    // …but only the strict both-tags+relay match is recorded as published fact.
+    expect(markNip85Activated).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/services/trustAnchor.ts
+++ b/client/src/services/trustAnchor.ts
@@ -10,36 +10,140 @@
  */
 import { apiClient } from "./api";
 import {
+  fetchOutboxRelayList,
+  fetchTrustProviderList,
   getNip85RelayUrl,
   isUsingBrainstorm,
   publishToRelays,
   signNip85,
 } from "./nostr";
 import { activeAccount, canSignSilently } from "@/accounts/signing";
+import { isUnlockCancelled } from "@/accounts/local-signer";
 import { identityHas } from "@/accounts/display";
 import { accountKey } from "@/lib/accountStorage";
 import { isNip85Activated, markNip85Activated } from "@/lib/nip85Activation";
+import { hasDeclinedNip85, hasNip85Consent, recordNip85Consent } from "@/lib/nip85Consent";
 
 /**
- * Kick off WoT scoring and, for in-app-created accounts only, the background
+ * Whether the automatic (non-user-initiated) NIP-85 publish paths may run for
+ * this account. An explicit yes on the consent card enables them for every
+ * account type; an explicit no disables them even for in-app-created accounts,
+ * whose signup used to be their only consent. Accounts that were never asked
+ * (legacy sessions) keep the old createdInApp-implies-consent behavior.
+ */
+export function shouldAutoPublishNip85(pubkey: string): boolean {
+  if (hasNip85Consent(pubkey)) return true;
+  return identityHas(pubkey, "createdInApp") && !hasDeclinedNip85(pubkey);
+}
+
+/**
+ * Kick off WoT scoring and, when the account consented, the background
  * trust-anchor publish. Called once the user has actually followed ≥1 account
  * (the "calculate my scores" CTA) — NOT at account creation, since a follow-less
  * account can't be scored.
  *
- * Computing scores (`triggerGrapeRank`) publishes nothing under the user's key
- * and just populates their `ta_pubkey`, so it always runs. Publishing the NIP-85
- * provider declaration (kind 10040) is a public act under their key, so we only
- * auto-do it for accounts created here (signing up via Brainstorm = consent).
- * Existing users select Brainstorm explicitly via the dashboard card / Settings
- * (with a replace-warning) — we never overwrite a provider choice they didn't
- * make here.
+ * Computing scores (`triggerGrapeRank`) publishes nothing under the user's key,
+ * so it always runs. Publishing the NIP-85 provider declaration (kind 10040) is
+ * a public act under their key, so it's gated on consent — captured by the
+ * consent card next to the calculate CTA (`opts.nip85Consent`), or implied by
+ * having signed up in-app for accounts that were never shown the card.
+ *
+ * The poll here is only the fallback for when the caller couldn't publish
+ * immediately (ta_pubkey not fetched yet); the calculate surfaces try
+ * `publishBrainstormTrustAnchor` first, while the user is present to sign.
  */
-export async function triggerScoringAndAnchor(pubkey: string): Promise<void> {
+export async function triggerScoringAndAnchor(
+  pubkey: string,
+  opts?: { nip85Consent?: boolean },
+): Promise<void> {
+  if (opts?.nip85Consent !== undefined) recordNip85Consent(pubkey, opts.nip85Consent);
   // Mark the start so the global status chip can show "Calculating…" immediately,
   // before the backend's graperankResult reflects an in-progress record.
   try { localStorage.setItem(accountKey("brainstorm_calc_triggered_at", pubkey), String(Date.now())); } catch {}
   try { await apiClient.triggerGrapeRank(); } catch {}
-  if (identityHas(pubkey, "createdInApp")) void pollAndPublishTrustAnchor(pubkey);
+  if (shouldAutoPublishNip85(pubkey)) void pollAndPublishTrustAnchor(pubkey);
+}
+
+/**
+ * What a kind-10040 on the user's outbox relays currently says, for the consent
+ * card's pre-check. "brainstorm" means their declaration already names THEIR
+ * assistant — nothing to ask; "other" means what's there would be replaced, so
+ * the card must warn and default to off; "none"/"unknown" mean go ahead and
+ * ask. Best-effort: relay silence reads as "none", a thrown setup problem as
+ * "unknown" — neither ever blocks the calculate CTA.
+ *
+ * The bar for "brainstorm" is exact: the rank pubkey must equal the user's own
+ * Brainstorm assistant (`ta_pubkey`). Any 10040 is NOT enough — assistants are
+ * per-user keys, so a declaration naming a Brainstorm relay but someone else's
+ * (or a stale) assistant would leave the rest of the flow reading scores that
+ * aren't theirs. When `ta_pubkey` isn't known yet we therefore classify an
+ * existing declaration as "other"; the card re-checks once /user/history
+ * delivers the key, and the exact match settles it.
+ */
+export type TrustProviderStatus = "none" | "brainstorm" | "other" | "unknown";
+
+export async function checkExistingTrustProvider(
+  pubkey: string,
+  taPubkey?: string | null,
+): Promise<TrustProviderStatus> {
+  try {
+    // Warm the eventStore with their kind-10002 first, so the 10040 read (and
+    // any publish after it) routes to their real outbox relays — on the
+    // onboarding surfaces the dashboard's warm-up hasn't run yet.
+    await fetchOutboxRelayList(pubkey);
+    if (taPubkey && (await isUsingBrainstorm(pubkey, taPubkey))) {
+      // Published from another device — record it so nothing re-asks.
+      markNip85Activated(pubkey);
+      return "brainstorm";
+    }
+    const event = await fetchTrustProviderList(pubkey);
+    const rankTarget = event?.tags.find((t) => t[0] === "30382:rank")?.[1];
+    if (!rankTarget) return "none";
+    return rankTarget === taPubkey ? "brainstorm" : "other";
+  } catch {
+    return "unknown";
+  }
+}
+
+export type TrustAnchorPublishResult =
+  | { status: "success" }
+  | { status: "cancelled"; unlockDeclined: boolean }
+  | { status: "error"; message: string };
+
+/**
+ * The user-initiated NIP-85 publish: sign the kind-10040 selecting Brainstorm
+ * and broadcast it to the user's outbox relays. Unlike
+ * `ensureBrainstormTrustAnchor` this MAY raise the unlock modal or the
+ * extension/bunker prompt — the user just asked for it (consent card or the
+ * dashboard modal). `onPhase` lets callers narrate signing vs publishing.
+ */
+export async function publishBrainstormTrustAnchor(
+  pubkey: string,
+  taPubkey: string,
+  onPhase?: (phase: "signing" | "publishing") => void,
+): Promise<TrustAnchorPublishResult> {
+  let nip85Relay: string;
+  try {
+    nip85Relay = getNip85RelayUrl();
+  } catch (err: any) {
+    return { status: "error", message: err?.message || "NIP-85 relay URL is not configured." };
+  }
+
+  onPhase?.("signing");
+  let signed;
+  try {
+    signed = await signNip85(taPubkey, nip85Relay);
+  } catch (err) {
+    return { status: "cancelled", unlockDeclined: isUnlockCancelled(err) };
+  }
+
+  onPhase?.("publishing");
+  const result = await publishToRelays(signed);
+  if (result.success) {
+    markNip85Activated(pubkey);
+    return { status: "success" };
+  }
+  return { status: "error", message: result.error || "Failed to publish to relays. Please try again." };
 }
 
 /**

--- a/client/src/services/trustAnchor.ts
+++ b/client/src/services/trustAnchor.ts
@@ -21,7 +21,8 @@ import { activeAccount, canSignSilently } from "@/accounts/signing";
 import { isUnlockCancelled } from "@/accounts/local-signer";
 import { identityHas } from "@/accounts/display";
 import { accountKey } from "@/lib/accountStorage";
-import { isNip85Activated, markNip85Activated } from "@/lib/nip85Activation";
+import { queryClient } from "@/lib/queryClient";
+import { clearNip85Activated, isNip85Activated, markNip85Activated } from "@/lib/nip85Activation";
 import { hasDeclinedNip85, hasNip85Consent, recordNip85Consent } from "@/lib/nip85Consent";
 
 /**
@@ -99,6 +100,15 @@ export async function checkExistingTrustProvider(
     const event = await fetchTrustProviderList(pubkey);
     const rankTarget = event?.tags.find((t) => t[0] === "30382:rank")?.[1];
     if (!rankTarget) return "none";
+    if (taPubkey && rankTarget !== taPubkey) {
+      // Definitive contrary evidence: a 10040 exists and names a different
+      // assistant. Unlike a relay MISS (absence, never a downgrade), presence
+      // of a foreign declaration means the local "activated" flag is now a
+      // lie — the on-relay 10040 takes precedence, so drop the flag and let
+      // every surface reflect the truth.
+      clearNip85Activated(pubkey);
+      return "other";
+    }
     return rankTarget === taPubkey ? "brainstorm" : "other";
   } catch {
     return "unknown";
@@ -141,6 +151,8 @@ export async function publishBrainstormTrustAnchor(
   const result = await publishToRelays(signed);
   if (result.success) {
     markNip85Activated(pubkey);
+    // The on-relay answer changed — every badge/status reading it must re-ask.
+    void queryClient.invalidateQueries({ queryKey: ["trust-provider-status"] });
     return { status: "success" };
   }
   return { status: "error", message: result.error || "Failed to publish to relays. Please try again." };
@@ -162,19 +174,23 @@ export async function ensureBrainstormTrustAnchor(pubkey: string, taPubkey: stri
   const account = activeAccount();
   if (!account || account.pubkey !== pubkey) return;
   if (!(await canSignSilently(account))) return;
-  // Already declared Brainstorm on relays (e.g. published from another device)?
-  // Record it locally and stop — nothing to publish.
+  // What does their 10040 on relays say? "brainstorm" → recorded, done (e.g.
+  // published from another device). "other" → THEIR DECLARATION WINS: this is
+  // the automatic path, and it must never replace a provider the user chose —
+  // `isUsingBrainstorm === false` alone can't tell "no declaration" from
+  // "declared someone else", which is how a foreign 10040 could get silently
+  // overwritten. Replacement happens only on the explicit surfaces (consent
+  // card / modal), behind the replace warning.
   try {
-    if (await isUsingBrainstorm(pubkey, taPubkey)) {
-      markNip85Activated(pubkey);
-      return;
-    }
+    const existing = await checkExistingTrustProvider(pubkey, taPubkey);
+    if (existing === "brainstorm" || existing === "other") return;
   } catch {}
   try {
     const signed = await signNip85(taPubkey, getNip85RelayUrl());
     const res = await publishToRelays(signed);
     if (res.success) {
       markNip85Activated(pubkey);
+      void queryClient.invalidateQueries({ queryKey: ["trust-provider-status"] });
     }
   } catch {}
 }


### PR DESCRIPTION
## What

First-time users were only asked to publish their NIP-85 kind-10040 declaration *after* calculation and TA publishing completed (dashboard CTA), and in-app accounts got a silent background publish. But the 10040 is independent of scoring — the backend mints each user's assistant key at first auth and `/user/history` returns it immediately — so the rest of the flow was waiting on nothing.

This moves the ask to a consent card beside every "calculate my scores" CTA (`OnboardingWizard`, `WelcomePage`, `FollowToCalculateCard`) and, with consent, signs + publishes the 10040 right at commit, while the user is present and the signer is warm from the kind-3.

## Details

- **Pre-check on outbox relays** (`checkExistingTrustProvider`): warms the kind-10002 list, then reads the existing 10040. The bar for "already set" is exact — **any 10040 is not enough; its `30382:rank` pubkey must equal the user's own Brainstorm assistant** (`ta_pubkey`). A declaration naming anything else (or one we can't verify yet because history hasn't delivered the key) shows a replace warning and defaults the toggle **off**.
- **Consent is per-account** (`lib/nip85Consent`, localStorage): an explicit decline beats the `createdInApp` implicit consent everywhere (background poll, app-load self-heal), and re-surfaces the dashboard CTA after the existing 7-day cooldown. Legacy callers of `triggerScoringAndAnchor` keep the old behavior.
- **One publish path**: `publishBrainstormTrustAnchor` extracted from `ActivateBrainstormModal`; modal, onboarding and welcome all share it. Explainer copy extracted to `nip85Explainer.tsx`, shared by card and modal.
- Fallbacks unchanged in mechanism: consent-gated background poll + `AutoActivateBrainstorm` self-heal + dashboard CTA.

## Tests

New vitest coverage: consent record roundtrip/isolation, `shouldAutoPublishNip85` gating (decline beats createdInApp), publish success/cancel/error + phase narration, pre-check classification (incl. the exact-assistant rule), consent-card render states, and wizard consent pass-through.

## Staging

New cycle (previous pin `feat-share-card-routing` is a fossil). After CI is green: pin `ui.image.tag: feat-nip85-consent-at-calculate` in brainstorm-k8s and `./deploy_staging.sh --ui`. Do not merge this PR to promote to staging — merge to main promotes to prod via `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANmSPcb5Pfjm7jZs1DJ9eF

---

## Also in this cycle: never publish a from-scratch follow list on a guess

A deep-dive found kind-3 wipe risk in the "no follows yet" flows: for an imported key on a fresh device, a silently-failed login-time fetch plus a commit-time fetch that misses the real list (kind-10002 not in the eventStore → only the hardcoded profile relays get asked) let `followPubkeys` publish a fresh short kind-3 over a user's real one. Applesauce offers no protection here (its `FollowUser` is already avoided for the same failure).

- `resolveContactBase` now warms the outbox list and retries before concluding; "nothing found anywhere" for a non-`createdInApp` key refuses to publish (`needsBaseConfirmation`) until the user explicitly confirms via `ConfirmNewFollowListDialog` ("I've never followed anyone — continue"). Same guard on `followUser`.
- The follow-picker surfaces (dashboard card, home nudge, thread nudge) verify "no follows" against relays via `useVerifiedNoFollows` before rendering, repairing the local floor when a list is found. WelcomePage awaits the publish for at-risk keys so the dialog can be answered.
- Login-time floor fetch retries via the warmed outbox list; publishes verify in the background that our event became the newest kind-3 and warn if a relay still serves an older, shorter list.


---

## Also: the on-relay 10040 takes precedence over every local claim

Follow-up audit of NIP-85 precedence. Trust **reads** were already per-observer (`trustSource.ts`, pinned by `tags.trustRouting.test.ts`). Two state-side violations closed:

- `ensureBrainstormTrustAnchor` (background poll + `AutoActivateBrainstorm`) gated only on `isUsingBrainstorm === false`, which can't tell "no declaration" from "declared someone else" — it could silently replace a foreign 10040. The automatic path now backs off from any declaration naming a different assistant; replacement stays exclusive to the explicit surfaces with the replace warning.
- The dashboard "Active" badge, Settings provider row, and user panel trusted the never-downgrading `nip85Activated` flag. A definitive foreign declaration (rank pubkey ≠ the user's assistant) now clears the flag; relay silence still never downgrades. All three surfaces share one relay-backed `useTrustProviderStatus` query, invalidated on every publish/deactivate.
