### PR TITLE
Prompt un-activated accounts to sign their kind-10040

### DIFF
--- a/client/src/components/ActivateBrainstormInterstitial.test.tsx
+++ b/client/src/components/ActivateBrainstormInterstitial.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/utils";
+import { ActivateBrainstormInterstitial } from "./ActivateBrainstormInterstitial";
+
+describe("ActivateBrainstormInterstitial", () => {
+  it("frames activation as the last step of an almost-finished checklist", () => {
+    renderWithProviders(
+      <ActivateBrainstormInterstitial scoresReady onActivate={() => {}} onDismiss={() => {}} />,
+    );
+
+    expect(screen.getByTestId("interstitial-step-signin")).toHaveTextContent("Signed in");
+    expect(screen.getByTestId("interstitial-step-scores")).toHaveTextContent("Scores calculated");
+    expect(screen.getByTestId("interstitial-step-activate")).toHaveTextContent(
+      "Activate your account",
+    );
+    expect(screen.getByTestId("text-interstitial-title")).toHaveTextContent(
+      "Activate your Brainstorm account",
+    );
+    expect(screen.getByTestId("text-interstitial-subtitle")).toHaveTextContent(
+      "Sign a note that tells other apps where to find your Brainstorm scores.",
+    );
+  });
+
+  // Activation doesn't wait for scores — mid-calculation the step shows as
+  // underway and says so, while the signature stays collectable.
+  it("shows scores as underway, not blocking, while the first calculation runs", () => {
+    renderWithProviders(
+      <ActivateBrainstormInterstitial scoresReady={false} onActivate={() => {}} onDismiss={() => {}} />,
+    );
+
+    expect(screen.getByTestId("interstitial-step-scores")).toHaveTextContent(
+      "Calculating your scores",
+    );
+    expect(screen.getByTestId("interstitial-step-scores")).toHaveTextContent(
+      "Keeps running while you activate.",
+    );
+    expect(screen.getByTestId("button-interstitial-activate")).toBeEnabled();
+  });
+
+  it("shows the consequence — locked apps that can't read the scores", () => {
+    renderWithProviders(
+      <ActivateBrainstormInterstitial scoresReady onActivate={() => {}} onDismiss={() => {}} />,
+    );
+
+    expect(screen.getByTestId("interstitial-app-amethyst")).toBeInTheDocument();
+    expect(screen.getByTestId("interstitial-app-nostria")).toBeInTheDocument();
+    expect(screen.getByTestId("interstitial-apps-locked")).toHaveTextContent(
+      "Amethyst and Nostria can't see your scores yet.",
+    );
+  });
+
+  it("opens the signing flow from the primary button", () => {
+    const onActivate = vi.fn();
+    renderWithProviders(
+      <ActivateBrainstormInterstitial scoresReady onActivate={onActivate} onDismiss={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByTestId("button-interstitial-activate"));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user defer — with the consequence named on the link", () => {
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <ActivateBrainstormInterstitial scoresReady onActivate={() => {}} onDismiss={onDismiss} />,
+    );
+
+    const later = screen.getByTestId("button-interstitial-later");
+    expect(later).toHaveTextContent("Maybe later — my scores stay invisible in other apps for now");
+    fireEvent.click(later);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/ActivateBrainstormInterstitial.tsx
+++ b/client/src/components/ActivateBrainstormInterstitial.tsx
@@ -1,0 +1,177 @@
+import { motion } from "framer-motion";
+import { Check, FileSignature, Loader2, Lock } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { BrainLogo } from "@/components/BrainLogo";
+import amethystLogoImg from "@/assets/amethyst-logo.png";
+import nostriaIconImg from "@/assets/nostria-icon.png";
+
+/**
+ * Full-page takeover shown on the dashboard when the account still needs to
+ * sign its kind-10040 (see `needsActivationPrompt`). The dashboard's other
+ * panels all radiate "everything is done", which buried the inline prompt —
+ * so until the one action that makes scores visible in other apps happens,
+ * the page shows only this.
+ *
+ * Framed as finishing setup, not complying: two checklist steps are already
+ * earned, one remains. "Maybe later" is per-visit — the caller keeps the
+ * dismissal in component state so navigating away and back re-raises it — and
+ * its copy carries the consequence honestly.
+ */
+
+function AppBadge({ src, alt, testId }: { src: string; alt: string; testId: string }) {
+  return (
+    <div className="relative" data-testid={testId}>
+      {/* Grayed, not erased — the logos must stay recognizable for "these
+          specific apps are locked" to land. */}
+      <img
+        src={src}
+        alt={alt}
+        className="w-10 h-10 rounded-xl grayscale opacity-75 bg-white object-contain border border-slate-200 dark:border-slate-700"
+      />
+      <span className="absolute -bottom-1 -right-1 h-4 w-4 rounded-full bg-slate-200 dark:bg-slate-700 border border-white dark:border-slate-900 flex items-center justify-center">
+        <Lock className="h-2.5 w-2.5 text-slate-500 dark:text-slate-300" />
+      </span>
+    </div>
+  );
+}
+
+interface StepProps {
+  state: "done" | "active" | "busy";
+  label: string;
+  sub?: string;
+  testId: string;
+}
+
+function ChecklistStep({ state, label, sub, testId }: StepProps) {
+  return (
+    <div className="flex items-start gap-3" data-testid={testId}>
+      {state === "done" ? (
+        <span className="h-6 w-6 rounded-full bg-emerald-500 flex items-center justify-center shrink-0 mt-px">
+          <Check className="h-3.5 w-3.5 text-white" />
+        </span>
+      ) : state === "busy" ? (
+        <span className="h-6 w-6 rounded-full bg-brand-primary/10 border border-brand-primary/25 flex items-center justify-center shrink-0 mt-px">
+          <Loader2 className="h-3.5 w-3.5 text-brand-link animate-spin" />
+        </span>
+      ) : (
+        <span className="h-6 w-6 rounded-full bg-brand-primary/10 border-2 border-brand-primary flex items-center justify-center shrink-0 mt-px">
+          <FileSignature className="h-3 w-3 text-brand-link" />
+        </span>
+      )}
+      <div className="min-w-0">
+        <p
+          className={`text-sm leading-6 ${
+            state === "active"
+              ? "font-bold text-slate-900 dark:text-slate-100"
+              : "font-medium text-slate-600 dark:text-slate-300"
+          }`}
+        >
+          {label}
+        </p>
+        {sub && <p className="text-xs text-slate-400 dark:text-slate-500 leading-relaxed">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+interface ActivateBrainstormInterstitialProps {
+  /** First calculation finished — flips step two from busy to done. */
+  scoresReady: boolean;
+  onActivate: () => void;
+  onDismiss: () => void;
+}
+
+export function ActivateBrainstormInterstitial({
+  scoresReady,
+  onActivate,
+  onDismiss,
+}: ActivateBrainstormInterstitialProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+      className="flex-1 flex items-center justify-center py-6"
+      data-testid="interstitial-activate-brainstorm"
+    >
+      <Card accent className="w-full max-w-xl overflow-hidden">
+        <div className="p-6 sm:p-8">
+          <div className="flex items-center gap-2.5 mb-3">
+            <span className="text-[11px] font-mono font-bold tracking-[0.25em] text-brand-link uppercase">
+              One step left
+            </span>
+            <div className="h-px w-10 bg-brand-link/30" />
+          </div>
+
+          <h1
+            className="text-2xl sm:text-3xl font-bold text-slate-900 dark:text-slate-100 tracking-tight leading-[1.15]"
+            style={{ fontFamily: "var(--font-display)" }}
+            data-testid="text-interstitial-title"
+          >
+            Activate your <span className="text-brand-link">Brainstorm</span> account
+          </h1>
+          <p
+            className="text-sm sm:text-[15px] text-slate-600 dark:text-slate-300 mt-2.5 leading-relaxed"
+            data-testid="text-interstitial-subtitle"
+          >
+            Sign a note that tells other apps where to find your Brainstorm scores.
+          </p>
+
+          <div className="mt-6 space-y-4" data-testid="interstitial-checklist">
+            <ChecklistStep state="done" label="Signed in" testId="interstitial-step-signin" />
+            {scoresReady ? (
+              <ChecklistStep state="done" label="Scores calculated" testId="interstitial-step-scores" />
+            ) : (
+              <ChecklistStep
+                state="busy"
+                label="Calculating your scores…"
+                sub="Keeps running while you activate."
+                testId="interstitial-step-scores"
+              />
+            )}
+            <ChecklistStep
+              state="active"
+              label="Activate your account"
+              sub="Takes one signature."
+              testId="interstitial-step-activate"
+            />
+          </div>
+
+          <div
+            className="mt-6 flex items-center gap-3 rounded-xl bg-slate-50/80 dark:bg-slate-800/40 border border-slate-200/70 dark:border-slate-800 px-4 py-3"
+            data-testid="interstitial-apps-locked"
+          >
+            <div className="flex items-center gap-2">
+              <AppBadge src={amethystLogoImg} alt="Amethyst" testId="interstitial-app-amethyst" />
+              <AppBadge src={nostriaIconImg} alt="Nostria" testId="interstitial-app-nostria" />
+            </div>
+            <p className="text-xs sm:text-[13px] text-slate-500 dark:text-slate-400 leading-snug">
+              Amethyst and Nostria can't see your scores yet.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onActivate}
+            className="mt-6 w-full h-12 rounded-xl bg-brand-primary hover:bg-brand-primary-hover text-white font-bold text-sm tracking-wide shadow-lg shadow-brand-primary/20 transition-all duration-200 flex items-center justify-center gap-2"
+            data-testid="button-interstitial-activate"
+          >
+            <BrainLogo mono size={16} className="text-white" />
+            Activate Brainstorm
+          </button>
+
+          <div className="mt-4 text-center">
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+              data-testid="button-interstitial-later"
+            >
+              Maybe later — my scores stay invisible in other apps for now
+            </button>
+          </div>
+        </div>
+      </Card>
+    </motion.div>
+  );
+}

--- a/client/src/components/ActivateBrainstormModal.tsx
+++ b/client/src/components/ActivateBrainstormModal.tsx
@@ -74,6 +74,15 @@ export function ActivateBrainstormModal({ open, onOpenChange, serviceKey, onActi
       return;
     }
 
+    // Signing with an empty service key would publish a 10040 pointing at
+    // nothing. The dashboard disables its buttons until ta_pubkey exists, but
+    // never rely on callers for that.
+    if (!serviceKey) {
+      setActivateState("error");
+      setErrorMessage("Your account is still being prepared — please try again in a few minutes.");
+      return;
+    }
+
     let nip85Relay: string;
     try {
       nip85Relay = getNip85RelayUrl();

--- a/client/src/components/ActivateBrainstormPanel.test.tsx
+++ b/client/src/components/ActivateBrainstormPanel.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/utils";
+import {
+  ActivateBrainstormPanel,
+  needsActivationPrompt,
+  type ActivationCheckResult,
+} from "./ActivateBrainstormPanel";
+
+const check = (found: boolean, matches: boolean): ActivationCheckResult => ({ found, matches });
+
+describe("needsActivationPrompt", () => {
+  it("stays hidden until the relay check settles", () => {
+    expect(
+      needsActivationPrompt({ check: undefined, locallyActivated: false, createdInApp: false }),
+    ).toBe(false);
+  });
+
+  it("never prompts in-app-created accounts (they auto-activate)", () => {
+    expect(
+      needsActivationPrompt({ check: check(false, false), locallyActivated: false, createdInApp: true }),
+    ).toBe(false);
+    expect(
+      needsActivationPrompt({ check: check(true, false), locallyActivated: false, createdInApp: true }),
+    ).toBe(false);
+  });
+
+  it("prompts an account with no kind-10040", () => {
+    expect(
+      needsActivationPrompt({ check: check(false, false), locallyActivated: false, createdInApp: false }),
+    ).toBe(true);
+  });
+
+  // Relays are eventually-consistent; once we've published, a miss is lag, not
+  // a deactivation (mirrors nip85Activation.ts).
+  it("does not re-prompt on a relay miss once locally activated", () => {
+    expect(
+      needsActivationPrompt({ check: check(false, false), locallyActivated: true, createdInApp: false }),
+    ).toBe(false);
+  });
+
+  it("prompts when the 10040 points at a different provider, even if locally activated", () => {
+    expect(
+      needsActivationPrompt({ check: check(true, false), locallyActivated: true, createdInApp: false }),
+    ).toBe(true);
+  });
+
+  it("stays hidden when the 10040 already declares Brainstorm", () => {
+    expect(
+      needsActivationPrompt({ check: check(true, true), locallyActivated: false, createdInApp: false }),
+    ).toBe(false);
+  });
+});
+
+describe("ActivateBrainstormPanel", () => {
+  it("carries the activation copy", () => {
+    renderWithProviders(<ActivateBrainstormPanel onActivate={() => {}} />);
+
+    expect(screen.getByTestId("text-activate-brainstorm-title")).toHaveTextContent(
+      "Activate your Brainstorm account",
+    );
+    expect(screen.getByTestId("text-activate-brainstorm-subtitle")).toHaveTextContent(
+      "Sign a note that tells other apps where to find your Brainstorm scores.",
+    );
+  });
+
+  // ta_pubkey exists from login (the backend creates it while minting the
+  // session token), so the button is always live — no waiting state.
+  it("opens the signing flow on click", () => {
+    const onActivate = vi.fn();
+    renderWithProviders(<ActivateBrainstormPanel onActivate={onActivate} />);
+
+    fireEvent.click(screen.getByTestId("button-activate-brainstorm"));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/ActivateBrainstormPanel.tsx
+++ b/client/src/components/ActivateBrainstormPanel.tsx
@@ -1,0 +1,97 @@
+import { motion } from "framer-motion";
+import { Card } from "@/components/ui/card";
+import { BrainLogo } from "@/components/BrainLogo";
+
+/** Relay truth about this account's NIP-85 declaration, once the check settles. */
+export interface ActivationCheckResult {
+  /** A kind-10040 exists on the account's relays. */
+  found: boolean;
+  /** …and it names Brainstorm's TA on our relay as the provider. */
+  matches: boolean;
+}
+
+/**
+ * Should the dashboard prompt this account to activate — i.e. sign the
+ * kind-10040 that tells other apps where to find their Brainstorm scores?
+ *
+ * Deliberately NOT gated on any calculation state: the failure this prompt
+ * fixes is users who left before their scores finished publishing and so never
+ * saw the legacy consent card (which waits for publishDone), went to Amethyst
+ * or Nostria, and found no trace of their scores. Signing needs only the
+ * account's ta_pubkey, which the backend creates during login itself
+ * (authChallenge verify), so the action is always performable here.
+ *
+ * - Check not settled yet → hidden; never flash the prompt at someone who may
+ *   already be activated.
+ * - In-app-created accounts → hidden; signing up here was the consent, and
+ *   AutoActivateBrainstorm publishes their declaration for them.
+ * - 10040 found → the event decides. One pointing elsewhere shows the prompt
+ *   even when the local flag says activated (they switched providers from
+ *   another app; re-selecting Brainstorm is exactly the remedy).
+ * - No 10040 found → prompt only when the account isn't locally marked
+ *   activated: absence can be relay lag, and per `nip85Activation.ts` we never
+ *   downgrade on a transient miss.
+ */
+export function needsActivationPrompt(opts: {
+  check: ActivationCheckResult | undefined;
+  locallyActivated: boolean;
+  createdInApp: boolean;
+}): boolean {
+  const { check, locallyActivated, createdInApp } = opts;
+  if (!check || createdInApp) return false;
+  if (check.found) return !check.matches;
+  return !locallyActivated;
+}
+
+/**
+ * Full-width dashboard banner prompting the user to activate their Brainstorm
+ * account (sign the kind-10040). This is the follow-up reminder that remains
+ * in place after the full-page ActivateBrainstormInterstitial is dismissed
+ * with "maybe later" (and the only prompt for zero-follow accounts, whose
+ * critical path is the follow-picker, not activation). Uses the design
+ * system's `accent` surface. No dismissal by design — it self-hides on
+ * activation.
+ */
+export function ActivateBrainstormPanel({ onActivate }: { onActivate: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+    >
+      <Card accent className="overflow-hidden" data-testid="card-activate-brainstorm">
+        <div className="p-5 sm:p-6 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+          <div className="h-12 w-12 rounded-2xl bg-brand-primary shadow-sm shadow-brand-primary/25 flex items-center justify-center shrink-0">
+            <BrainLogo mono size={24} className="text-white" />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <h2
+              className="text-lg sm:text-xl font-bold text-slate-900 dark:text-slate-100 tracking-tight leading-tight"
+              style={{ fontFamily: "var(--font-display)" }}
+              data-testid="text-activate-brainstorm-title"
+            >
+              Activate your Brainstorm account
+            </h2>
+            <p
+              className="text-xs sm:text-sm text-slate-500 dark:text-slate-400 mt-1 leading-relaxed"
+              data-testid="text-activate-brainstorm-subtitle"
+            >
+              Sign a note that tells other apps where to find your Brainstorm scores.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onActivate}
+            className="w-full sm:w-auto h-11 px-6 rounded-xl bg-brand-primary hover:bg-brand-primary-hover text-white font-bold text-xs sm:text-sm tracking-wide shadow-lg shadow-brand-primary/20 transition-all duration-200 flex items-center justify-center gap-2 shrink-0"
+            data-testid="button-activate-brainstorm"
+          >
+            <BrainLogo mono size={16} className="text-white" />
+            Activate Brainstorm
+          </button>
+        </div>
+      </Card>
+    </motion.div>
+  );
+}

--- a/client/src/lib/nip85Declaration.test.ts
+++ b/client/src/lib/nip85Declaration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { NostrEvent } from "applesauce-core/helpers";
+
+import { declaresTrustProvider } from "./nip85Declaration";
+
+const TA = "a".repeat(64);
+const OTHER_TA = "b".repeat(64);
+const RELAY = "wss://nip85.example.com";
+
+function event10040(tags: string[][]): NostrEvent {
+  return {
+    id: "0".repeat(64),
+    pubkey: "c".repeat(64),
+    created_at: 1700000000,
+    kind: 10040,
+    tags,
+    content: "",
+    sig: "d".repeat(128),
+  };
+}
+
+describe("declaresTrustProvider", () => {
+  it("accepts a declaration naming our TA on our relay for both rank and followers", () => {
+    const event = event10040([
+      ["30382:rank", TA, RELAY],
+      ["30382:followers", TA, RELAY],
+    ]);
+    expect(declaresTrustProvider(event, TA, RELAY)).toBe(true);
+  });
+
+  it("rejects a declaration pointing at a different TA", () => {
+    const event = event10040([
+      ["30382:rank", OTHER_TA, RELAY],
+      ["30382:followers", OTHER_TA, RELAY],
+    ]);
+    expect(declaresTrustProvider(event, TA, RELAY)).toBe(false);
+  });
+
+  // Brainstorm publishes both metrics; a rank-only declaration is stale or
+  // partial, and prompting for a re-sign is the remedy.
+  it("rejects when the followers tag is missing", () => {
+    const event = event10040([["30382:rank", TA, RELAY]]);
+    expect(declaresTrustProvider(event, TA, RELAY)).toBe(false);
+  });
+
+  it("rejects when the relay hint differs", () => {
+    const event = event10040([
+      ["30382:rank", TA, "wss://elsewhere.example.com"],
+      ["30382:followers", TA, "wss://elsewhere.example.com"],
+    ]);
+    expect(declaresTrustProvider(event, TA, RELAY)).toBe(false);
+  });
+
+  // An empty-tags 10040 is the NIP-85 deactivation form.
+  it("rejects a deactivation (empty tag list)", () => {
+    expect(declaresTrustProvider(event10040([]), TA, RELAY)).toBe(false);
+  });
+
+  // Guards the caller that hasn't been assigned a TA yet — an empty expected
+  // key must never accidentally match a malformed tag.
+  it("rejects when the expected TA is empty", () => {
+    const event = event10040([
+      ["30382:rank", "", RELAY],
+      ["30382:followers", "", RELAY],
+    ]);
+    expect(declaresTrustProvider(event, "", RELAY)).toBe(false);
+  });
+
+  it("accepts when matching tags sit among unrelated ones", () => {
+    const event = event10040([
+      ["30382:rank", OTHER_TA, RELAY],
+      ["30382:rank", TA, RELAY],
+      ["30382:followers", TA, RELAY],
+      ["30382:hops", TA, RELAY],
+    ]);
+    expect(declaresTrustProvider(event, TA, RELAY)).toBe(true);
+  });
+});

--- a/client/src/lib/nip85Declaration.ts
+++ b/client/src/lib/nip85Declaration.ts
@@ -1,0 +1,21 @@
+import type { NostrEvent } from "applesauce-core/helpers";
+
+/**
+ * Does this kind-10040 declare `taPubkey` (publishing on `relayUrl`) as the
+ * holder's trust provider? Brainstorm publishes rank AND followers assertions,
+ * so a declaration only counts when both tags name our TA on our relay — the
+ * semantics `isUsingBrainstorm` has always had, extracted so callers that
+ * already hold the event (the dashboard's activation check) can ask the
+ * question without re-fetching it.
+ */
+export function declaresTrustProvider(event: NostrEvent, taPubkey: string, relayUrl: string): boolean {
+  if (!taPubkey || !relayUrl) return false;
+  let rank = false;
+  let followers = false;
+  for (const tag of event.tags) {
+    if (tag[1] !== taPubkey || String(tag[2]) !== String(relayUrl)) continue;
+    if (tag[0] === "30382:rank") rank = true;
+    if (tag[0] === "30382:followers") followers = true;
+  }
+  return rank && followers;
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -113,7 +113,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { cacheProfile, fetchProfile, fetchOutboxRelayList, isUsingBrainstorm } from "@/services/nostr";
+import { cacheProfile, fetchProfile, fetchOutboxRelayList, fetchTrustProviderList, getNip85RelayUrl } from "@/services/nostr";
+import { declaresTrustProvider } from "@/lib/nip85Declaration";
 import { logout } from "@/accounts/login-flow";
 import { useActiveAccountDisplay } from "@/hooks/useActiveAccountDisplay";
 import { DeferredSessionNotice } from "@/components/DeferredSession";
@@ -123,6 +124,12 @@ import { TIER_LABELS } from "@/services/trustThreshold";
 import { useSelfOverview, useSelfHistory, useSelfStats } from "@/hooks/useSelf";
 import { toPubkeys } from "../services/graphHelpers";
 import { ActivateBrainstormModal } from "@/components/ActivateBrainstormModal";
+import {
+  ActivateBrainstormPanel,
+  needsActivationPrompt,
+  type ActivationCheckResult,
+} from "@/components/ActivateBrainstormPanel";
+import { ActivateBrainstormInterstitial } from "@/components/ActivateBrainstormInterstitial";
 
 import protocolDevImg from "@/assets/stock_images/protocol_dev.jpg";
 import bitcoinImg from "@/assets/stock_images/bitcoin_network.jpg";
@@ -365,28 +372,69 @@ export default function DashboardPage() {
   const stats = statsQuery.data?.data ?? null;
 
   const taPubkey = history?.ta_pubkey;
-  const trustServiceProvider = useQuery({
-    queryKey: ["trustServiceProvider", user?.pubkey, taPubkey],
+  // Relay truth for the activation prompt AND the "Active" badge upgrade: does
+  // this account's kind-10040 exist, and does it point at our TA on our relay?
+  // Waits only for /user/history to SETTLE (success or failure) — not for any
+  // calculation — so `matches` is computed against the real ta_pubkey rather
+  // than a still-loading null, which would flash the prompt at an account that
+  // is already activated. A 10040 found while ta_pubkey is genuinely absent is
+  // a mismatch: whoever it names, it isn't the TA we'd assign this account.
+  const historySettled = historyQuery.isSuccess || historyQuery.isError;
+  const activationCheck = useQuery<ActivationCheckResult>({
+    queryKey: ["nip85ActivationCheck", user?.pubkey, taPubkey ?? null],
     queryFn: async () => {
-      if (!user?.pubkey || !taPubkey) return false;
-      return await isUsingBrainstorm(user.pubkey, taPubkey);
+      const event = user?.pubkey ? await fetchTrustProviderList(user.pubkey) : undefined;
+      if (!event) return { found: false, matches: false };
+      let matches = false;
+      try {
+        matches = !!taPubkey && declaresTrustProvider(event, taPubkey, getNip85RelayUrl());
+      } catch {
+        /* relay URL unconfigured — treat as not matching; the modal surfaces it */
+      }
+      return { found: true, matches };
     },
-    enabled: !!user && !!taPubkey,
+    enabled: !!user && historySettled,
     retry: 2,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
     staleTime: Infinity,
   });
 
   useEffect(() => {
-    // Upgrade-only: a relay confirmation (isUsingBrainstorm === true) marks this
-    // account activated and shows the badge. A `false`/undefined is treated as
+    // Upgrade-only: a relay confirmation (`matches`) marks this account
+    // activated and shows the badge. A `false`/undefined is treated as
     // "not propagated yet", NOT a deactivation — relays are eventually-consistent,
     // so we never downgrade here (that caused the badge to flicker right after an
     // auto-publish). Deactivation is explicit, via Settings.
-    if (trustServiceProvider.data !== true) return;
+    if (activationCheck.data?.matches !== true) return;
     markNip85Activated(user?.pubkey);
     if (!nip85Activated) setNip85Activated(true);
-  }, [trustServiceProvider.data, nip85Activated]);
+  }, [activationCheck.data, nip85Activated]);
+
+  const showActivatePrompt = needsActivationPrompt({
+    check: activationCheck.data,
+    locallyActivated: nip85Activated,
+    createdInApp: nip85CreatedInApp,
+  });
+
+  // Note: ta_pubkey needs no waiting — the backend creates it during login
+  // itself (authChallenge verify), so for any session-holder the first
+  // /user/history response already carries it. Signing is always performable.
+
+  // The full-page activation takeover. "Maybe later" is deliberately
+  // component state, not storage: it reveals the dashboard for THIS visit
+  // only, and navigating away and back re-raises the takeover.
+  const [activationGateDismissed, setActivationGateDismissed] = useState(false);
+  // Brief first-paint hold for accounts that LOOK un-activated (local flag),
+  // so the takeover doesn't rug-pull a fully rendered dashboard once the
+  // relay check settles ~1–3s in. Activated accounts skip the hold via the
+  // flag; the cap lets the dashboard through if relays are slow (the
+  // takeover then swaps in late, which is the lesser evil).
+  const [activationHoldExpired, setActivationHoldExpired] = useState(false);
+  useEffect(() => {
+    if (activationCheck.isFetched) return;
+    const t = setTimeout(() => setActivationHoldExpired(true), 4000);
+    return () => clearTimeout(t);
+  }, [activationCheck.isFetched]);
 
   const grapeRankRaw = grapeRankQuery.data?.data;
   const grapeRank = grapeRankRaw && typeof grapeRankRaw === "object" ? grapeRankRaw : null;
@@ -771,6 +819,69 @@ export default function DashboardPage() {
   // flag — both caused brand-new accounts to read as "Recalculating".
   const isRecalculation = !publishDone && hadPreviousScores;
 
+  // One modal instance, reachable from both the takeover and the dashboard.
+  const activateModal = (
+    <ActivateBrainstormModal
+      open={nip85ModalOpen}
+      onOpenChange={setNip85ModalOpen}
+      serviceKey={history?.ta_pubkey || ""}
+      onActivated={() => {
+        setNip85Activated(true);
+        // The 10040 we just published IS the new relay state — record it
+        // rather than refetching into propagation lag, which could re-raise
+        // the activation prompt we're dismissing.
+        queryClient.setQueryData(["nip85ActivationCheck", user?.pubkey, taPubkey ?? null], {
+          found: true,
+          matches: true,
+        } satisfies ActivationCheckResult);
+        setNip85ModalOpen(false);
+        toast({ title: "Brainstorm activated!", description: "Your scores are now available across the nostr ecosystem." });
+      }}
+    />
+  );
+
+  // Zero-follow accounts are exempt from the takeover: their critical path is
+  // the follow-picker (scores can't exist without follows), and stacking two
+  // mandatory-feeling flows helps neither. They keep the inline panel below.
+  const showActivationGate = showActivatePrompt && !activationGateDismissed && !hasNoFollowing;
+  const holdForActivationCheck =
+    !activationCheck.isFetched &&
+    !activationHoldExpired &&
+    !nip85Activated &&
+    !nip85CreatedInApp &&
+    !activationGateDismissed &&
+    !hasNoFollowing;
+
+  if (showActivationGate || holdForActivationCheck) {
+    return (
+      <TooltipProvider>
+        <div className="min-h-screen bg-[#F8FAFC] dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-sans selection:bg-brand-primary/[0.3] flex flex-col relative overflow-hidden" data-testid="page-dashboard">
+          <PageBackground />
+
+          <AppHeader user={user} onLogout={handleLogout} calcDone={calcDone} active="dashboard" />
+
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-8 relative z-10 w-full flex-1 flex flex-col">
+            {showActivationGate ? (
+              <ActivateBrainstormInterstitial
+                scoresReady={calcDone}
+                onActivate={() => setNip85ModalOpen(true)}
+                onDismiss={() => setActivationGateDismissed(true)}
+              />
+            ) : (
+              <div className="flex-1 flex items-center justify-center" data-testid="activation-check-hold">
+                <Loader2 className="h-6 w-6 animate-spin text-brand-primary/50" />
+              </div>
+            )}
+          </div>
+
+          {activateModal}
+
+          <Footer minimal />
+        </div>
+      </TooltipProvider>
+    );
+  }
+
   return (
     <TooltipProvider>
       <div className="min-h-screen bg-[#F8FAFC] dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-sans selection:bg-brand-primary/[0.3] flex flex-col relative overflow-hidden" data-testid="page-dashboard">
@@ -964,6 +1075,14 @@ export default function DashboardPage() {
                       <Loader2 className="w-3 h-3 animate-spin" />
                       Recalculating...
                     </span>
+                  ) : publishDone && showActivatePrompt ? (
+                    // Scores exist but no kind-10040 points at them — "Score:
+                    // 47" / "Complete" would be the very hunky-dory signals
+                    // that buried the activation prompt. Say what's missing;
+                    // outranks the score readout on purpose.
+                    <span className="text-xs text-amber-600 dark:text-amber-400 font-semibold" data-testid="text-overall-trust-score-sub">
+                      Not visible in apps yet
+                    </span>
                   ) : grapeRankScore ? (
                     <span className="text-xs text-slate-700 dark:text-slate-200 font-semibold" data-testid="text-overall-trust-score-sub">
                       Score: {grapeRankScore}
@@ -1033,6 +1152,14 @@ export default function DashboardPage() {
               )}
 
             </div>
+
+            {/* Activation prompt — the one thing a signed-in user may still have
+                to DO (sign their kind-10040) before their scores are visible in
+                other apps. Full-width, above everything, and deliberately not
+                waiting on any calculation state; see needsActivationPrompt. */}
+            {showActivatePrompt && (
+              <ActivateBrainstormPanel onActivate={() => setNip85ModalOpen(true)} />
+            )}
 
             <AlertDialog open={recalcConfirmOpen} onOpenChange={setRecalcConfirmOpen}>
               <AlertDialogContent
@@ -1199,7 +1326,12 @@ export default function DashboardPage() {
             <TaggedYouModule />
           </div>
 
-          {publishDone && !isRecalculating && !nip85Activated && !nip85Dismissed && !nip85CreatedInApp && (
+          {/* Legacy consent card — superseded by ActivateBrainstormPanel above,
+              which prompts without waiting for publishDone. Kept (for now) as the
+              fallback for when the relay check can't settle (isFetched covers the
+              error case, where the panel stays hidden); it never renders alongside
+              the panel. */}
+          {publishDone && !isRecalculating && !nip85Activated && !nip85Dismissed && !nip85CreatedInApp && activationCheck.isFetched && !showActivatePrompt && (
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
@@ -1255,16 +1387,7 @@ export default function DashboardPage() {
             </motion.div>
           )}
 
-          <ActivateBrainstormModal
-            open={nip85ModalOpen}
-            onOpenChange={setNip85ModalOpen}
-            serviceKey={history?.ta_pubkey || ""}
-            onActivated={() => {
-              setNip85Activated(true);
-              setNip85ModalOpen(false);
-              toast({ title: "Brainstorm activated!", description: "Your scores are now available across the nostr ecosystem." });
-            }}
-          />
+          {activateModal}
 
           {/* Investigate command bar — research entry point into the deep-dive
               analytics (/profile/:npub) for anyone in your network. */}

--- a/client/src/services/nostr.ts
+++ b/client/src/services/nostr.ts
@@ -1,5 +1,6 @@
 import { nip19, finalizeEvent, generateSecretKey, verifyEvent } from "nostr-tools";
 import { env } from "@/lib/runtimeEnv";
+import { declaresTrustProvider } from "@/lib/nip85Declaration";
 import { pool } from "@/lib/relayPool";
 import { eventStore } from "@/lib/eventStore";
 import { CONTENT_RELAYS, PROFILE_RELAYS } from "@/lib/relays";
@@ -304,24 +305,8 @@ export async function checkNip85Health(
 }
 
 export async function isUsingBrainstorm(pubkey: string, innerPubkey: string, timeoutMs = 10000): Promise<boolean> {
-  console.log("isUsingBrainstorm", pubkey, innerPubkey)
   const event = await fetchTrustProviderList(pubkey, timeoutMs)
-
-  let isUsingRank = false
-  let isUsingFollowers = false
-
-  if (event) {
-    for (const tag of event.tags) {
-      if (tag[0] === "30382:rank" && tag[1] === innerPubkey && tag[2] == NIP85_RELAY_URL) {
-        isUsingRank = true
-      }
-      if (tag[0] === "30382:followers" && tag[1] === innerPubkey && tag[2] == NIP85_RELAY_URL) {
-        isUsingFollowers = true
-      }
-    }
-  }
-
-  return isUsingRank && isUsingFollowers
+  return !!event && declaresTrustProvider(event, innerPubkey, NIP85_RELAY_URL)
 }
 
 export function loadOutboxRelayListFromDb(pubkey: string, currentRelays: string[]): string[] {


### PR DESCRIPTION
## Problem

Users log in at brainstorm.world, their scores get calculated, but they never sign their kind-10040 — so Amethyst and Nostria show no trace of their scores. The existing "Use your Brainstorm scores in other apps" card waits for `publishDone` (new users leave before it ever renders), and it sits among panels that all radiate "done", so the one action still owed never reads as urgent.

## What this does

Prompts by relay truth, without waiting on any calculation state:

- **Full-page interstitial** on the dashboard whenever the account needs activation: checklist framing (✓ Signed in · ✓/⏳ Scores calculated · ○ Activate your account), grayed **Amethyst & Nostria logos with lock badges** ("can't see your scores yet"), primary **Activate Brainstorm** button opening the existing consent modal, and *"Maybe later — my scores stay invisible in other apps for now."* Dismissal is per-visit component state — navigating away and back re-raises it. Zero-follow accounts are exempt (their critical path is the follow-picker). A brief capped first-paint hold keeps the takeover from rug-pulling an already-painted dashboard while the relay check settles.
- **Inline accent panel** directly under the welcome header remains as the post-dismissal reminder.
- **Status honesty:** the Trust Signals chip reads amber **"Not visible in apps yet"** instead of "Score: N" / "Complete" while unactivated, so the page stops contradicting the prompt.
- Visibility rule (`needsActivationPrompt`, relay-settled): no kind-10040 found → prompt, unless the account is locally marked activated (never downgrade on a transient relay miss, per `nip85Activation.ts`); a 10040 pointing at a different provider → prompt regardless; in-app-created accounts excluded (they auto-activate).
- `isUsingBrainstorm` refactored onto a shared pure `declaresTrustProvider` helper (one definition of "declares Brainstorm"); the legacy consent card is suppressed whenever the new prompt shows and survives only as the relay-check-error fallback.
- No `ta_pubkey` waiting states: the backend creates it during login (`authChallenge/{pubkey}/verify` → `get_or_create_brainstorm_observer_nsec_by_pubkey_on_db`), so signing is always performable. The modal now guards the empty-serviceKey path as a safety net. (Several existing comments claiming ta_pubkey arrives "after first score" are stale — follow-up audit tracked separately.)

## Verification

- `npm run check` clean.
- 930 tests: 928 pass; the 2 failures (`tags.detailStatus`, `tags.trustRouting` timeouts) reproduce on a clean `main` checkout on the dev machine (Node 22 vs pinned 24) — environmental, CI on main is green.
- 20 tests cover this feature: the visibility predicate matrix, `declaresTrustProvider` tag semantics, and both prompt surfaces (checklist states, locked-apps copy, activate/defer actions).
- Visually verified light/dark/mobile in the dev server against the staging backend (`brainstormserver-staging`), including the live mismatch case (a 10040 pointing at production's TA correctly raises the takeover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)