### PR TITLE
Show the NIP-85 ask while scores calculate, not after

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1210,7 +1210,13 @@ export default function DashboardPage() {
             <TaggedYouModule />
           </div>
 
-          {publishDone && !isRecalculating && !nip85Activated && !nip85Dismissed && (!nip85CreatedInApp || hasDeclinedNip85(user?.pubkey)) && (
+          {/* The ask must land while the user is still HERE — the 10040 is
+              independent of scoring (their assistant key exists from first
+              auth), so a returning user with follows signs it during the
+              "Calculating…" wait instead of having to come back after
+              publishDone. Gated off the no-follows states: that cohort gets
+              the consent card inside the follow picker instead. */}
+          {!!taPubkey && !isRecalculating && !hasNoFollowing && !followsChecking && !nip85Activated && !nip85Dismissed && (!nip85CreatedInApp || hasDeclinedNip85(user?.pubkey)) && (
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
Closes the remaining half of the consent-at-calculate intent (#56): a returning user who logs in **with** follows never passes a follow picker — scoring auto-triggers and the dashboard "Use your Brainstorm scores in other apps" card waited for `publishDone`, so anyone who left during the 5–10 minute calculation had to come back to sign their 10040.

The 10040 is independent of scoring and the assistant key exists from first auth, so the CTA now gates on `taPubkey` being known instead of `publishDone` — the ask (and signature) happens during the "Calculating…" wait, while the user is still on the site. The no-follows cohort is explicitly excluded (`!hasNoFollowing && !followsChecking`) — they get the consent card inside the follow picker and must not be double-asked.

One-gate change in `DashboardPage.tsx`; the modal, pre-check (exact assistant match + replace warning), and all publish guards are unchanged.

**Test:** fresh browser, log in with a key that has follows and no scores → the CTA card appears immediately alongside the "Calculating…" state → Select Brainstorm → sign → 10040 lands on relays minutes before scores finish.