### PR TITLE
Profile counts follow the perspective toggle

### DIFF
--- a/client/src/lib/trustFlags.ts
+++ b/client/src/lib/trustFlags.ts
@@ -9,6 +9,9 @@
  * Both inputs come from the house/network POV (`getUserStats({ house: true })`)
  * so the verdict is the same for every viewer of a shared link.
  */
+// The profile's DISPLAYED counts follow the perspective toggle since the
+// stats-PoV fix, but this verdict (and the flag banner's evidence count) keep
+// reading the house ledger — a verdict and its evidence come from one ledger.
 export function isFlaggedByReporters(
   verifiedReporters: number,
   verifiedFollowers: number,

--- a/client/src/pages/SharePage.tsx
+++ b/client/src/pages/SharePage.tsx
@@ -153,6 +153,15 @@ export default function SharePage() {
   // here on /p; /profile is the tucked-away advanced view).
   const rel = useRelationshipBadges(pubkey);
   const { pov: scorePov } = useScorePov();
+  // A USABLE personal point of view — the same rule ConnectionListPage applies
+  // to the follower lists, so a count and the list behind it can never come
+  // from different perspectives. `brainstorm_calc_completed` is a localStorage
+  // breadcrumb, not server truth; without it the personalized stats would be
+  // an empty perspective pretending to be one.
+  const calcDone = (() => {
+    try { return localStorage.getItem("brainstorm_calc_completed") === "true"; } catch { return false; }
+  })();
+  const myPov = loggedIn && calcDone && scorePov === "personalized";
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<ProfilePrefs>(EMPTY_PROFILE_PREFS);
@@ -292,14 +301,26 @@ export default function SharePage() {
     retry: false,
   });
 
-  // Per-section stats: total/verified counts per relationship. A shared link is
-  // public, so we always read the HOUSE (network) POV — the same numbers and the
-  // same "flagged" verdict every viewer sees, never the logged-in viewer's
-  // personalized perspective.
-  const statsQuery = useQuery({
-    queryKey: ["share-stats", pubkey],
+  // Per-section stats: total/verified counts per relationship — one query per
+  // point of view, the same shape the coin uses (overviewQuery/houseRankQuery).
+  //
+  // House is fetched ALWAYS: it serves logged-out viewers and it is the ledger
+  // the flag verdict reads (a verdict must be the same for every viewer). The
+  // personalized query runs only when the viewer has a usable personal PoV,
+  // and the DISPLAYED counts select between the two at render time — this
+  // used to be pinned `house: true` from the share-page era, which is why the
+  // coin followed the toggle and these numbers didn't (David's report).
+  const houseStatsQuery = useQuery({
+    queryKey: ["share-stats", pubkey, "house"],
     queryFn: () => apiClient.getUserStats(pubkey, { house: true }),
     enabled: !!pubkey,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+  const myStatsQuery = useQuery({
+    queryKey: ["share-stats", pubkey, "mine"],
+    queryFn: () => apiClient.getUserStats(pubkey),
+    enabled: !!pubkey && myPov,
     staleTime: 5 * 60_000,
     retry: false,
   });
@@ -465,17 +486,20 @@ export default function SharePage() {
   // The overview score is viewer-relative: house/network POV when logged out,
   // the viewer's own web-of-trust POV when logged in. That's the primary ring.
   const score01 = typeof overview?.influence === "number" ? overview.influence : null;
-  // Counts from the per-section stats endpoint (house POV). Followers/muters/
-  // reporters use the VERIFIED (web-of-trust) count; "following" uses the raw
-  // total (per CEO: total following is more meaningful than verified following).
-  const stats = statsQuery.data?.data as
-    | {
-        followed_by?: { verified?: number; total?: number };
-        following?: { total?: number; verified?: number };
-        muted_by?: { verified?: number; total?: number };
-        reported_by?: { verified?: number; total?: number };
-      }
-    | undefined;
+  // Counts from the per-section stats endpoint. Followers/muters/reporters use
+  // the VERIFIED (web-of-trust) count; "following" uses the raw total (per CEO:
+  // total following is more meaningful than verified following).
+  type ShareStats = {
+    followed_by?: { verified?: number; total?: number };
+    following?: { total?: number; verified?: number };
+    muted_by?: { verified?: number; total?: number };
+    reported_by?: { verified?: number; total?: number };
+  };
+  const houseStats = houseStatsQuery.data?.data as ShareStats | undefined;
+  const myStats = myStatsQuery.data?.data as ShareStats | undefined;
+  // The DISPLAYED counts follow the perspective toggle; house fills in while
+  // the personalized query is in flight so the row never blanks.
+  const stats = myPov ? myStats ?? houseStats : houseStats;
   const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
   // Each stat carries BOTH the web-of-trust-filtered (`verified`) and raw
   // (`total`, includes bots) count in one response — the StatToggle flips between
@@ -489,8 +513,14 @@ export default function SharePage() {
   const verifiedReporters = num(stats?.reported_by?.verified);
   const allReporters = num(stats?.reported_by?.total);
   // Flagged = reported by more than 5 verified accounts, +1 forgiven per 750
-  // verified followers (house POV → same verdict for every viewer).
-  const isFlagged = isFlaggedByReporters(verifiedReporters ?? 0, verifiedFollowers ?? 0);
+  // verified followers. The verdict reads the HOUSE ledger regardless of the
+  // toggle — same verdict for every viewer — and so does the banner's evidence
+  // count below, because a verdict and its evidence must come from one ledger.
+  const houseVerifiedReporters = num(houseStats?.reported_by?.verified);
+  const isFlagged = isFlaggedByReporters(
+    houseVerifiedReporters ?? 0,
+    num(houseStats?.followed_by?.verified) ?? 0,
+  );
   // House influence (0–1) from the backend, house POV.
   const houseScore01 = useMemo(() => {
     const r = houseRankQuery.data;
@@ -1015,7 +1045,7 @@ export default function SharePage() {
               <AlertTriangle className="h-4 w-4 text-red-600 shrink-0 mt-0.5" />
               <div className="min-w-0 text-xs leading-relaxed">
                 <span className="font-bold text-red-700">Flagged by the network</span>
-                <span className="text-red-700/90"> — reported by {verifiedReporters} verified {verifiedReporters === 1 ? "account" : "accounts"} in the network.</span>{" "}
+                <span className="text-red-700/90"> — reported by {houseVerifiedReporters} verified {houseVerifiedReporters === 1 ? "account" : "accounts"} in the network.</span>{" "}
                 <Link href={`/p/${rawId}/reporters`} className="font-semibold text-red-700 underline underline-offset-2 hover:text-red-800" data-testid="share-flag-reporters">See who</Link>
                 <span className="text-red-700/60"> · </span>
                 {/* TODO(phase2): point at /what-are-degrees once the explainer exists */}

--- a/client/src/services/eventStore.singleton.test.ts
+++ b/client/src/services/eventStore.singleton.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -22,7 +23,9 @@ import { describe, expect, it } from "vitest";
  * for the same reason the pool lives there — `services/nostr.ts` may import from
  * `lib/`, and not the other way about.
  */
-const SOURCE_ROOT = new URL("../", import.meta.url).pathname;
+// fileURLToPath, not `.pathname`: a checkout under a directory with a space in
+// its name gives `Project%20B`, which readdirSync cannot open.
+const SOURCE_ROOT = fileURLToPath(new URL("../", import.meta.url));
 
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {


### PR DESCRIPTION
## The bug (David's report, confirmed on staging and main)

On `/p/:id`, flipping the perspective toggle changes the avatar's Verification Score coin — but Verified Following / Verified Followers / Verified Muters / Verified Reporters never move.

Root cause: the stats query was hard-pinned to `getUserStats(pubkey, { house: true })` with no perspective in its cache key — a share-page-era decision ("a shared link is public, so we always read the HOUSE POV") that expired when `/p/:id` became the main profile page. The coin follows the toggle because it fetches both PoVs and selects at render time; the counts fetched House, once, forever.

## The fix

Mirrors the coin's two-query pattern:

- **House stats are always fetched** — they serve logged-out viewers and the flag verdict.
- **A personalized stats query** runs only when the viewer has a usable personal PoV — the same `signedIn && calc_completed && personalized` rule ConnectionListPage already applies to the lists behind these counts. That also closes a subtler inconsistency: a count could previously disagree with the list it opened.
- **Displayed counts select at render time** — instant flip, flip-back is a cache hit.

**One deliberate exception:** the flag verdict (`isFlaggedByReporters`) and the flag banner's "reported by N verified accounts" stay on the **house ledger under both perspectives** — a safety verdict and its evidence must be the same for every viewer (documented in `lib/trustFlags.ts`).

Also carries the `eventStore.singleton.test` `fileURLToPath` fix — `URL.pathname` breaks on any checkout path containing a space.

## Verification

- Live on jack: Brainstorm → **695 / 30,503 / 32 / 8**, matching unauthenticated `GET /user/{pk}/stats` exactly; My perspective → **687 / 18,160 / 18 / 5**; flips live with the toggle.
- `tsc --noEmit` clean · **959/959** tests · production build green.

The hops half of the same report ("hops stuck on personalized") is fixed separately on `feat/hops-follows-pov`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)