### PR TITLE
docs: link CLAUDE.md to the estate map (ECOSYSTEM.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # Brainstorm-UI
 
+Production web UI of the Brainstorm/Tapestry estate. The map of the estate's
+repos and deployments is
+[ECOSYSTEM.md](https://github.com/NosFabrica/protocols/blob/main/ECOSYSTEM.md)
+in `NosFabrica/protocols`.
+
 ## Agent skills
 
 ### Issue tracker


### PR DESCRIPTION
[ECOSYSTEM.md](https://github.com/NosFabrica/protocols/blob/main/ECOSYSTEM.md) in `NosFabrica/protocols` is the canonical inventory of the estate's repos and deployments, and its goal is that anyone landing in any estate repo can navigate to all the others. An audit of the estate's CLAUDE.md files found only `brainstorm_server`'s links back to it; this repo's did not mention it at all.

This adds a two-sentence pointer under the title, mirroring the phrasing already used in `brainstorm_server/CLAUDE.md`. Companion PRs add the same back-link to `tapestry` and `strfry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)